### PR TITLE
Feat/유저서비스

### DIFF
--- a/src/domain/user/application/index.ts
+++ b/src/domain/user/application/index.ts
@@ -1,0 +1,1 @@
+export * from './user.facade';

--- a/src/domain/user/application/user.facade.ts
+++ b/src/domain/user/application/user.facade.ts
@@ -1,4 +1,22 @@
 import { Injectable } from '@nestjs/common';
+import {
+  GetUserPointInfo,
+  UserService,
+  WriteUserPointCommand,
+} from '../domain';
 
 @Injectable()
-export class UserFacade {}
+export class UserFacade {
+  constructor(private readonly userService: UserService) {}
+
+  async getUserPoint(userId: number): Promise<GetUserPointInfo> {
+    const userPointInfo = await this.userService.getUserPoint(userId);
+    return userPointInfo;
+  }
+  async chargeUserPoint(
+    command: WriteUserPointCommand,
+  ): Promise<GetUserPointInfo> {
+    const userPointInfo = await this.userService.chargeUserPoint(command);
+    return userPointInfo;
+  }
+}

--- a/src/domain/user/application/user.facade.ts
+++ b/src/domain/user/application/user.facade.ts
@@ -1,4 +1,4 @@
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class PointService {}
+export class UserFacade {}

--- a/src/domain/user/domain/dto/command/index.ts
+++ b/src/domain/user/domain/dto/command/index.ts
@@ -1,0 +1,1 @@
+export * from './write-user-point-command.dto';

--- a/src/domain/user/domain/dto/command/write-user-point-command.dto.ts
+++ b/src/domain/user/domain/dto/command/write-user-point-command.dto.ts
@@ -1,9 +1,6 @@
-import { PointHistoryType } from '../../model/enum';
-
 type WriteUserPointCommandProp = {
   readonly userId: number;
   readonly amount: number;
-  readonly type: PointHistoryType;
 };
 
 export class WriteUserPointCommand {
@@ -15,10 +12,6 @@ export class WriteUserPointCommand {
 
   get amount() {
     return this.prop.amount;
-  }
-
-  get type() {
-    return this.prop.type;
   }
 
   static from(prop: WriteUserPointCommandProp) {

--- a/src/domain/user/domain/dto/command/write-user-point-command.dto.ts
+++ b/src/domain/user/domain/dto/command/write-user-point-command.dto.ts
@@ -1,0 +1,27 @@
+import { PointHistoryType } from '../../model/enum';
+
+type WriteUserPointCommandProp = {
+  readonly userId: number;
+  readonly amount: number;
+  readonly type: PointHistoryType;
+};
+
+export class WriteUserPointCommand {
+  constructor(private readonly prop: WriteUserPointCommandProp) {}
+
+  get userId() {
+    return this.prop.userId;
+  }
+
+  get amount() {
+    return this.prop.amount;
+  }
+
+  get type() {
+    return this.prop.type;
+  }
+
+  static from(prop: WriteUserPointCommandProp) {
+    return new WriteUserPointCommand(prop);
+  }
+}

--- a/src/domain/user/domain/dto/index.ts
+++ b/src/domain/user/domain/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './command';
+export * from './info';

--- a/src/domain/user/domain/dto/info/get-user-info.ts
+++ b/src/domain/user/domain/dto/info/get-user-info.ts
@@ -1,0 +1,16 @@
+import { UserEntity } from '../../model';
+
+export class GetUserInfo implements Pick<UserEntity, 'id' | 'name' | 'email'> {
+  constructor(
+    readonly id: number,
+    readonly name: string,
+    readonly email: string,
+  ) {}
+
+  static of(domain: UserEntity[]): GetUserInfo[];
+  static of(domain: UserEntity): GetUserInfo;
+  static of(domain: UserEntity | UserEntity[]): GetUserInfo | GetUserInfo[] {
+    if (Array.isArray(domain)) return domain.map((d) => this.of(d));
+    return new GetUserInfo(domain.id, domain.name, domain.email);
+  }
+}

--- a/src/domain/user/domain/dto/info/get-user-point-info.ts
+++ b/src/domain/user/domain/dto/info/get-user-point-info.ts
@@ -1,0 +1,17 @@
+import { PointEntity } from '../../model';
+
+export class GetUserPointInfo implements Pick<PointEntity, 'id' | 'amount'> {
+  constructor(
+    readonly id: number,
+    readonly amount: number,
+  ) {}
+
+  static of(domain: PointEntity[]): GetUserPointInfo[];
+  static of(domain: PointEntity): GetUserPointInfo;
+  static of(
+    domain: PointEntity | PointEntity[],
+  ): GetUserPointInfo | GetUserPointInfo[] {
+    if (Array.isArray(domain)) return domain.map((d) => this.of(d));
+    return new GetUserPointInfo(domain.id, domain.amount);
+  }
+}

--- a/src/domain/user/domain/dto/info/index.ts
+++ b/src/domain/user/domain/dto/info/index.ts
@@ -1,0 +1,2 @@
+export * from './get-user-info';
+export * from './get-user-point-info';

--- a/src/domain/user/domain/index.ts
+++ b/src/domain/user/domain/index.ts
@@ -1,0 +1,3 @@
+// export * from './dto';
+export * from './model';
+export * from './user.service';

--- a/src/domain/user/domain/index.ts
+++ b/src/domain/user/domain/index.ts
@@ -1,3 +1,3 @@
-// export * from './dto';
+export * from './dto';
 export * from './model';
 export * from './user.service';

--- a/src/domain/user/domain/model/enum/index.ts
+++ b/src/domain/user/domain/model/enum/index.ts
@@ -1,0 +1,1 @@
+export * from './point-history-type.enum';

--- a/src/domain/user/domain/model/enum/point-history-type.enum.ts
+++ b/src/domain/user/domain/model/enum/point-history-type.enum.ts
@@ -1,4 +1,4 @@
 export enum PointHistoryType {
-  CHARG = 'Charg',
+  CHARGE = 'Charge',
   USE = 'Use',
 }

--- a/src/domain/user/domain/model/index.ts
+++ b/src/domain/user/domain/model/index.ts
@@ -1,0 +1,4 @@
+export * from './enum';
+export * from './point-history.entity';
+export * from './point.entity';
+export * from './user.entity';

--- a/src/domain/user/domain/model/point-history.entity.ts
+++ b/src/domain/user/domain/model/point-history.entity.ts
@@ -1,15 +1,19 @@
 import { BaseEntity } from 'src/common';
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, JoinColumn } from 'typeorm';
 import { PointHistoryType } from './enum/point-history-type.enum';
 
 @Entity('point_history')
 export class PointHistoryEntity extends BaseEntity {
   @Column('int')
-  userId: number;
-
-  @Column('int')
   amount: number;
 
   @Column()
   type: PointHistoryType;
+
+  @Column('int')
+  @JoinColumn({
+    name: 'userId',
+    foreignKeyConstraintName: 'fk_point_history_userId',
+  })
+  userId: number;
 }

--- a/src/domain/user/domain/model/point.entity.ts
+++ b/src/domain/user/domain/model/point.entity.ts
@@ -1,8 +1,29 @@
-import { BaseEntity } from 'src/common';
+import { BaseEntity, ConflictStatusException } from 'src/common';
 import { Column, Entity } from 'typeorm';
 
 @Entity('point')
 export class PointEntity extends BaseEntity {
+  static readonly MIN_POINT = 0;
+
   @Column('int')
   amount: number;
+
+  /* ================================ Domain Method ================================ */
+
+  chargePoint(addPoint: number): this {
+    this.amount += addPoint;
+    return this;
+  }
+
+  usePoint(subAmount: number): this {
+    if (!this.canUsePoint(subAmount)) {
+      throw new ConflictStatusException('잔액이 부족합니다.');
+    }
+    this.amount -= subAmount;
+    return this;
+  }
+
+  canUsePoint(subAmount: number): boolean {
+    return this.amount - subAmount >= PointEntity.MIN_POINT;
+  }
 }

--- a/src/domain/user/domain/model/user.entity.ts
+++ b/src/domain/user/domain/model/user.entity.ts
@@ -1,5 +1,5 @@
 import { BaseEntity } from 'src/common';
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, JoinColumn } from 'typeorm';
 
 @Entity('user')
 export class UserEntity extends BaseEntity {
@@ -10,5 +10,9 @@ export class UserEntity extends BaseEntity {
   email: string;
 
   @Column('int')
+  @JoinColumn({
+    name: 'pointId',
+    foreignKeyConstraintName: 'fk_user_pointId',
+  })
   pointId: number;
 }

--- a/src/domain/user/domain/user.service.ts
+++ b/src/domain/user/domain/user.service.ts
@@ -1,8 +1,11 @@
 import { Injectable } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource, QueryFailedError } from 'typeorm';
+
 import { GetUserInfo, GetUserPointInfo, WriteUserPointCommand } from './dto';
 import { PointRepository, UserRepository } from '../infra';
-import { DataSource } from 'typeorm';
-import { InjectDataSource } from '@nestjs/typeorm';
+import { PointHistoryType } from './model/enum';
+import { ConflictStatusException } from 'src/common';
 
 @Injectable()
 export class UserService {
@@ -14,17 +17,80 @@ export class UserService {
   ) {}
 
   async getUser(userId: number): Promise<GetUserInfo> {
-    // return GetUserInfo.of();
-    return;
+    const user = await this.userRepo.getUserByPK(userId);
+    return GetUserInfo.of(user);
   }
 
   async getUserPoint(userId: number): Promise<GetUserPointInfo> {
-    return;
+    const user = await this.userRepo.getUserByPK(userId);
+    const point = await this.pointRepo.getPointByPk(user.pointId);
+    return GetUserPointInfo.of(point);
   }
 
   async chargeUserPoint(
     command: WriteUserPointCommand,
   ): Promise<GetUserPointInfo> {
-    return;
+    const { amount: chargeAmount, userId } = command;
+
+    return await this.dataSource
+      .transaction(async (txManager) => {
+        const txUser = this.userRepo.createTransactionRepo(txManager);
+        const txPointRepo = this.pointRepo.createTransactionRepo(txManager);
+
+        const user = await txUser.getUserByPK(userId);
+        const point = await txPointRepo.getPointByPk(user.pointId, {
+          lock: { mode: 'pessimistic_write_or_fail' },
+        });
+
+        point.chargePoint(chargeAmount);
+
+        await txPointRepo.updatePointWithHistory(user.pointId, {
+          // TODO: type를 넘기는 건 실수하기 너무 좋음, 개선필요
+          type: PointHistoryType.CHARGE,
+          amount: point.amount,
+        });
+        return GetUserPointInfo.of(point);
+      })
+      .catch((error) => {
+        if (
+          error instanceof QueryFailedError &&
+          error.message.includes('NOWAIT')
+        )
+          throw new ConflictStatusException('포인트 충전 요청 처리중입니다.');
+        else throw error;
+      });
+  }
+
+  async useUserPoint(
+    command: WriteUserPointCommand,
+  ): Promise<GetUserPointInfo> {
+    const { amount: chargeAmount, userId } = command;
+
+    return await this.dataSource
+      .transaction(async (txManager) => {
+        const txUser = this.userRepo.createTransactionRepo(txManager);
+        const txPointRepo = this.pointRepo.createTransactionRepo(txManager);
+
+        const user = await txUser.getUserByPK(userId);
+        const point = await txPointRepo.getPointByPk(user.pointId, {
+          lock: { mode: 'pessimistic_write_or_fail' },
+        });
+
+        point.usePoint(chargeAmount);
+
+        await txPointRepo.updatePointWithHistory(user.pointId, {
+          type: PointHistoryType.USE,
+          amount: point.amount,
+        });
+        return GetUserPointInfo.of(point);
+      })
+      .catch((error) => {
+        if (
+          error instanceof QueryFailedError &&
+          error.message.includes('NOWAIT')
+        )
+          throw new ConflictStatusException('포인트 사용 요청 처리중입니다.');
+        else throw error;
+      });
   }
 }

--- a/src/domain/user/domain/user.service.ts
+++ b/src/domain/user/domain/user.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { GetUserInfo, GetUserPointInfo, WriteUserPointCommand } from './dto';
+import { PointRepository, UserRepository } from '../infra';
+import { DataSource } from 'typeorm';
+import { InjectDataSource } from '@nestjs/typeorm';
+
+@Injectable()
+export class UserService {
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    private readonly userRepo: UserRepository,
+    private readonly pointRepo: PointRepository,
+  ) {}
+
+  async getUser(userId: number): Promise<GetUserInfo> {
+    // return GetUserInfo.of();
+    return;
+  }
+
+  async getUserPoint(userId: number): Promise<GetUserPointInfo> {
+    return;
+  }
+
+  async chargeUserPoint(
+    command: WriteUserPointCommand,
+  ): Promise<GetUserPointInfo> {
+    return;
+  }
+}

--- a/src/domain/user/index.ts
+++ b/src/domain/user/index.ts
@@ -1,0 +1,5 @@
+export * from './presentation';
+export * from './application';
+export * from './domain';
+export * from './infra';
+export * from './user.module';

--- a/src/domain/user/infra/index.ts
+++ b/src/domain/user/infra/index.ts
@@ -1,0 +1,4 @@
+export * from './point-core.repository';
+export * from './point.repository';
+export * from './user-core.repository';
+export * from './user.repository';

--- a/src/domain/user/infra/point-core.repository.ts
+++ b/src/domain/user/infra/point-core.repository.ts
@@ -1,0 +1,4 @@
+import { BaseRepository } from 'src/common';
+import { PointEntity } from '../domain';
+
+export abstract class PointRepository extends BaseRepository<PointEntity> {}

--- a/src/domain/user/infra/point-core.repository.ts
+++ b/src/domain/user/infra/point-core.repository.ts
@@ -1,4 +1,47 @@
-import { BaseRepository } from 'src/common';
-import { PointEntity } from '../domain';
+import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
 
-export abstract class PointRepository extends BaseRepository<PointEntity> {}
+import { PointEntity, PointHistoryEntity } from '../domain';
+import {
+  FindLockOptions,
+  PointRepository,
+  UpdatePointParam,
+} from './point.repository';
+import { RunTimeException } from 'src/common';
+
+@Injectable()
+export class PointCoreRepository extends PointRepository {
+  readonly pointHistoryRepo: Repository<PointHistoryEntity>;
+
+  constructor(
+    @InjectEntityManager()
+    readonly manager: EntityManager,
+  ) {
+    super(PointEntity, manager);
+    this.pointHistoryRepo = manager.getRepository(PointHistoryEntity);
+  }
+
+  override async getPointByPk(
+    pointId: number,
+    options: FindLockOptions = {},
+  ): Promise<PointEntity> {
+    const point = await this.findOne({
+      where: { id: pointId },
+      lock: { ...options.lock },
+    });
+
+    // Note: 로직상 point가 존재하지 않으면 데이터 자체의 오류이다.
+    if (!point) throw new RunTimeException('포인트가 존재하지 않습니다.');
+    return point;
+  }
+
+  override async updatePointWithHistory(
+    pointId: number,
+    param: UpdatePointParam,
+  ): Promise<void> {
+    const { amount, type } = param;
+    await this.update(pointId, { amount: param.amount });
+    await this.pointHistoryRepo.insert({ amount, type });
+  }
+}

--- a/src/domain/user/infra/point.repository.ts
+++ b/src/domain/user/infra/point.repository.ts
@@ -1,0 +1,14 @@
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
+
+import { PointEntity } from '../domain';
+import { PointRepository } from './point-core.repository';
+
+export class PointCoreRepository extends PointRepository {
+  constructor(
+    @InjectEntityManager()
+    readonly manager: EntityManager,
+  ) {
+    super(PointEntity, manager);
+  }
+}

--- a/src/domain/user/infra/point.repository.ts
+++ b/src/domain/user/infra/point.repository.ts
@@ -1,14 +1,18 @@
-import { InjectEntityManager } from '@nestjs/typeorm';
-import { EntityManager } from 'typeorm';
-
+import { FindOneOptions } from 'typeorm';
+import { BaseRepository } from 'src/common';
 import { PointEntity } from '../domain';
-import { PointRepository } from './point-core.repository';
+import { PointHistoryType } from '../domain/model/enum';
 
-export class PointCoreRepository extends PointRepository {
-  constructor(
-    @InjectEntityManager()
-    readonly manager: EntityManager,
-  ) {
-    super(PointEntity, manager);
-  }
+export type UpdatePointParam = { type: PointHistoryType; amount: number };
+export type FindLockOptions = Pick<FindOneOptions, 'lock'>;
+
+export abstract class PointRepository extends BaseRepository<PointEntity> {
+  abstract getPointByPk(
+    pointId: number,
+    options?: FindLockOptions,
+  ): Promise<PointEntity>;
+  abstract updatePointWithHistory(
+    pointId: number,
+    param: UpdatePointParam,
+  ): Promise<void>;
 }

--- a/src/domain/user/infra/user-core.repository.ts
+++ b/src/domain/user/infra/user-core.repository.ts
@@ -1,4 +1,21 @@
-import { BaseRepository } from 'src/common';
-import { UserEntity } from '../domain';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
 
-export abstract class UserRepository extends BaseRepository<UserEntity> {}
+import { ResourceNotFoundException } from 'src/common';
+import { UserEntity } from '../domain';
+import { UserRepository } from './user.repository';
+
+export class UserCoreRepository extends UserRepository {
+  constructor(
+    @InjectEntityManager()
+    readonly manager: EntityManager,
+  ) {
+    super(UserEntity, manager);
+  }
+
+  override async getUserByPK(userId: number): Promise<UserEntity> {
+    const user = await this.findOneBy({ id: userId });
+    if (!user) throw new ResourceNotFoundException('유저가 존재하지 않습니다.');
+    return user;
+  }
+}

--- a/src/domain/user/infra/user-core.repository.ts
+++ b/src/domain/user/infra/user-core.repository.ts
@@ -1,0 +1,4 @@
+import { BaseRepository } from 'src/common';
+import { UserEntity } from '../domain';
+
+export abstract class UserRepository extends BaseRepository<UserEntity> {}

--- a/src/domain/user/infra/user.repository.ts
+++ b/src/domain/user/infra/user.repository.ts
@@ -1,14 +1,7 @@
-import { InjectEntityManager } from '@nestjs/typeorm';
-import { EntityManager } from 'typeorm';
+import { BaseRepository } from 'src/common';
 
-import { UserRepository } from './user-core.repository';
 import { UserEntity } from '../domain';
 
-export class UserCoreRepository extends UserRepository {
-  constructor(
-    @InjectEntityManager()
-    readonly manager: EntityManager,
-  ) {
-    super(UserEntity, manager);
-  }
+export abstract class UserRepository extends BaseRepository<UserEntity> {
+  abstract getUserByPK(userId: number): Promise<UserEntity>;
 }

--- a/src/domain/user/infra/user.repository.ts
+++ b/src/domain/user/infra/user.repository.ts
@@ -1,0 +1,14 @@
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
+
+import { UserRepository } from './user-core.repository';
+import { UserEntity } from '../domain';
+
+export class UserCoreRepository extends UserRepository {
+  constructor(
+    @InjectEntityManager()
+    readonly manager: EntityManager,
+  ) {
+    super(UserEntity, manager);
+  }
+}

--- a/src/domain/user/point/point.module.ts
+++ b/src/domain/user/point/point.module.ts
@@ -1,7 +1,0 @@
-import { Module } from '@nestjs/common';
-import { PointService } from './point.service';
-
-@Module({
-  providers: [PointService],
-})
-export class PointModule {}

--- a/src/domain/user/presentation/dto/response/post-user-point-response.dto.ts
+++ b/src/domain/user/presentation/dto/response/post-user-point-response.dto.ts
@@ -1,4 +1,6 @@
+import { plainToInstance } from 'class-transformer';
 import { RestApiIntProperty } from 'src/common';
+import { GetUserPointInfo } from 'src/domain/user/domain';
 
 export class GetUserPointResponse {
   @RestApiIntProperty({
@@ -7,4 +9,13 @@ export class GetUserPointResponse {
     default: 1,
   })
   amount: number;
+
+  static of(info: GetUserPointInfo): GetUserPointResponse;
+  static of(info: GetUserPointInfo[]): GetUserPointResponse[];
+  static of(
+    info: GetUserPointInfo | GetUserPointInfo[],
+  ): GetUserPointResponse | GetUserPointResponse[] {
+    if (Array.isArray(info)) return info.map((i) => this.of(i));
+    return plainToInstance(GetUserPointResponse, { info });
+  }
 }

--- a/src/domain/user/presentation/index.ts
+++ b/src/domain/user/presentation/index.ts
@@ -1,0 +1,3 @@
+export * from './document';
+export * from './dto';
+export * from './user.controller';

--- a/src/domain/user/presentation/user.controller.ts
+++ b/src/domain/user/presentation/user.controller.ts
@@ -2,29 +2,36 @@ import { Body, Controller, Get, HttpCode, Param, Patch } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { DocumentHelper } from './document';
 import { GetUserPointResponse, PatchUserPointRequest } from './dto';
+import { UserFacade } from '../application';
+import { WriteUserPointCommand } from '../domain';
 
 @ApiTags('유저 포인트 API')
 @Controller({ path: 'users' })
 export class UserController {
+  constructor(private readonly userFacade: UserFacade) {}
+
   @DocumentHelper('getUserPoint')
   @Get(':userId/point')
   async getUserPoint(
-    @Param('userId') userId: string,
+    @Param('userId') userId: number,
   ): Promise<GetUserPointResponse> {
-    return {
-      amount: 10000,
-    };
+    const user = await this.userFacade.getUserPoint(userId);
+    return GetUserPointResponse.of(user);
   }
 
   @DocumentHelper('patchUserPoint')
   @Patch(':userId/point')
   @HttpCode(201)
   async patchUserPoint(
-    @Param('userId') userId: string,
+    @Param('userId') userId: number,
     @Body() body: PatchUserPointRequest,
   ): Promise<GetUserPointResponse> {
-    return {
-      amount: 10000,
-    };
+    const user = await this.userFacade.chargeUserPoint(
+      WriteUserPointCommand.from({
+        userId,
+        amount: body.amount,
+      }),
+    );
+    return GetUserPointResponse.of(user);
   }
 }

--- a/src/domain/user/user.module.ts
+++ b/src/domain/user/user.module.ts
@@ -1,9 +1,28 @@
 import { Module } from '@nestjs/common';
+
 import { UserController } from './presentation/user.controller';
-import { PointModule } from './point/point.module';
+import { UserService } from './domain/user.service';
+import { UserFacade } from './application';
+import {
+  PointCoreRepository,
+  PointRepository,
+  UserCoreRepository,
+  UserRepository,
+} from './infra';
 
 @Module({
-  imports: [PointModule],
   controllers: [UserController],
+  providers: [
+    UserFacade,
+    UserService,
+    {
+      provide: UserRepository,
+      useClass: UserCoreRepository,
+    },
+    {
+      provide: PointRepository,
+      useClass: PointCoreRepository,
+    },
+  ],
 })
 export class UserModule {}

--- a/test/fixture/mock-entity-generator.ts
+++ b/test/fixture/mock-entity-generator.ts
@@ -4,6 +4,7 @@ import {
   SeatEntity,
   SeatStatus,
 } from 'src/domain/concert/performance';
+import { PointEntity, UserEntity } from 'src/domain/user';
 
 export class MockEntityGenerator {
   static generatePerformance(id: number, concertId: number): PerformanceEntity {
@@ -29,5 +30,29 @@ export class MockEntityGenerator {
     seat.status = SeatStatus.AVAILABLE;
     seat.performanceId = performanceId;
     return seat;
+  }
+
+  static generateUser(param: { id: number; pointId: number }) {
+    const user = new UserEntity();
+
+    user.id = param.id;
+    user.createdAt = new Date();
+    user.updatedAt = new Date();
+    user.pointId = param.pointId;
+    user.name = faker.person.fullName();
+    user.email = faker.internet.email({
+      firstName: user.name,
+    });
+
+    return user;
+  }
+
+  static generatePoint(param: { id: number; amount?: number }) {
+    const point = new PointEntity();
+    point.id = param.id;
+    point.createdAt = new Date();
+    point.updatedAt = new Date();
+    point.amount = param.amount ?? 0;
+    return point;
   }
 }

--- a/test/user/unit/user.service.spec.ts
+++ b/test/user/unit/user.service.spec.ts
@@ -1,0 +1,318 @@
+import { type MockProxy, mock } from 'jest-mock-extended';
+import { DataSource } from 'typeorm';
+
+import {
+  GetUserPointInfo,
+  PointRepository,
+  UserRepository,
+  UserService,
+  WriteUserPointCommand,
+} from 'src/domain/user';
+import {
+  ConflictStatusException,
+  ResourceNotFoundException,
+  RunTimeException,
+} from 'src/common';
+import { MockEntityGenerator } from 'test/fixture';
+import { GetUserInfo } from 'src/domain/user';
+
+describe('UserService', () => {
+  let mockDataSource: MockProxy<DataSource>;
+  let userRepo: MockProxy<UserRepository>;
+  let pointRepo: MockProxy<PointRepository>;
+  let service: UserService;
+
+  beforeEach(() => {
+    mockDataSource = mock<DataSource>();
+    userRepo = mock<UserRepository>();
+    pointRepo = mock<PointRepository>();
+    service = new UserService(mockDataSource, userRepo, pointRepo);
+  });
+
+  describe('getUser', () => {
+    describe('실패한다.', () => {
+      it('유저가 존재하지 않으면 실패한다.', async () => {
+        // given
+        const userId = -1;
+        const success = ResourceNotFoundException;
+
+        // mock
+        userRepo.getUserByPK.mockRejectedValue(new ResourceNotFoundException());
+
+        // when & then
+        await expect(service.getUser(userId)) //
+          .rejects.toBeInstanceOf(success);
+      });
+    });
+
+    describe('성공한다.', () => {
+      it('유저 ID에 해당하는 유저 조회에 성공한다.', async () => {
+        // given
+        const userId = -1;
+        const userEntity = MockEntityGenerator.generateUser({
+          id: userId,
+          pointId: 1,
+        });
+        const success = GetUserInfo.of(userEntity);
+
+        // mock
+        userRepo.getUserByPK.mockResolvedValue(userEntity);
+
+        const result = await service.getUser(userId);
+        // when & then
+        expect(result).toEqual(success);
+      });
+    });
+  });
+
+  describe('getUserPoint', () => {
+    describe('실패한다.', () => {
+      it('유저가 존재하지 않으면 포인트 조회에 실패한다.', async () => {
+        // given
+        const userId = -1;
+        const success = ResourceNotFoundException;
+
+        // mock
+        userRepo.getUserByPK.mockRejectedValue(new ResourceNotFoundException());
+
+        // when & then
+        await expect(service.getUserPoint(userId)) //
+          .rejects.toBeInstanceOf(success);
+      });
+
+      it('유저에게 포인트가 존재하지 않으면 실패한다.', async () => {
+        // given
+        const userId = -1;
+        const userEntity = MockEntityGenerator.generateUser({
+          id: userId,
+          pointId: 1,
+        });
+        const success = RunTimeException;
+
+        // mock
+        userRepo.getUserByPK.mockResolvedValue(userEntity);
+        pointRepo.getPointByPk.mockRejectedValue(new RunTimeException());
+
+        // when & then
+        await expect(service.getUserPoint(userId)) //
+          .rejects.toBeInstanceOf(success);
+      });
+    });
+
+    describe('성공한다.', () => {
+      it('유저가 존재하고 유저가 포인트를 가지고 있으면 성공한다.', async () => {
+        // given
+        const userId = -1;
+        const pointId = 1;
+        const userEntity = MockEntityGenerator.generateUser({
+          id: userId,
+          pointId,
+        });
+        const pointEntity = MockEntityGenerator.generatePoint({ id: pointId });
+        const success = GetUserPointInfo.of(pointEntity);
+
+        // mock
+        userRepo.getUserByPK.mockResolvedValue(userEntity);
+        pointRepo.getPointByPk.mockResolvedValue(pointEntity);
+
+        const result = await service.getUserPoint(userId);
+        // when & then
+        expect(result).toEqual(success);
+      });
+    });
+  });
+
+  describe('chargeUserPoint', () => {
+    describe('실패한다.', () => {
+      it('유저가 존재하지 않으면 실패한다.', async () => {
+        // given
+        const command = WriteUserPointCommand.from({
+          userId: -1,
+          amount: 100_000,
+        });
+        const success = ResourceNotFoundException;
+
+        // mock transaction
+        mockDataSource.transaction.mockImplementation(async (cb) =>
+          cb(mockDataSource),
+        );
+        userRepo.createTransactionRepo.mockReturnValue(userRepo);
+        pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
+
+        // mock
+        userRepo.getUserByPK.mockRejectedValue(new ResourceNotFoundException());
+
+        // when & then
+        await expect(service.chargeUserPoint(command)) //
+          .rejects.toBeInstanceOf(success);
+      });
+
+      it('유저에게 포인트가 존재하지 않으면 실패한다.', async () => {
+        // given
+        const command = WriteUserPointCommand.from({
+          userId: 1,
+          amount: 100_000,
+        });
+        const userEntity = MockEntityGenerator.generateUser({
+          id: command.userId,
+          pointId: null,
+        });
+        const success = RunTimeException;
+
+        // mock transaction
+        mockDataSource.transaction.mockImplementation(async (cb) =>
+          cb(mockDataSource),
+        );
+        userRepo.createTransactionRepo.mockReturnValue(userRepo);
+        pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
+
+        // mock
+        userRepo.getUserByPK.mockResolvedValue(userEntity);
+        pointRepo.getPointByPk.mockRejectedValue(new RunTimeException());
+
+        // when & then
+        await expect(service.chargeUserPoint(command)) //
+          .rejects.toBeInstanceOf(success);
+      });
+    });
+
+    describe('성공한다.', () => {
+      it('유저가 존재하고 유저가 포인트를 가지고 있으면 충전에 성공한다.', async () => {
+        // given
+        const pointId = 1;
+        const command = WriteUserPointCommand.from({
+          userId: 1,
+          amount: 100_000,
+        });
+        const userEntity = MockEntityGenerator.generateUser({
+          id: command.userId,
+          pointId,
+        });
+        const pointEntity = MockEntityGenerator.generatePoint({
+          id: pointId,
+          amount: 100_000,
+        });
+        const success = pointEntity.amount + command.amount;
+
+        // mock transaction
+        mockDataSource.transaction.mockImplementation(async (cb) =>
+          cb(mockDataSource),
+        );
+        userRepo.createTransactionRepo.mockReturnValue(userRepo);
+        pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
+
+        // mock
+        userRepo.getUserByPK.mockResolvedValue(userEntity);
+        pointRepo.getPointByPk.mockResolvedValue(pointEntity);
+        pointRepo.updatePointWithHistory.mockResolvedValue();
+
+        const result = await service.chargeUserPoint(command);
+
+        // when & then
+        expect(result.amount).toBe(success);
+      });
+    });
+  });
+
+  describe('useUserPoint', () => {
+    describe('실패한다.', () => {
+      it('유저에게 포인트가 존재하지 않으면 사용에 실패한다.', async () => {
+        // given
+        const command = WriteUserPointCommand.from({
+          userId: 1,
+          amount: 100000,
+        });
+        const userEntity = MockEntityGenerator.generateUser({
+          id: command.userId,
+          pointId: null,
+        });
+        const success = RunTimeException;
+
+        // mock transaction
+        mockDataSource.transaction.mockImplementation(async (cb) =>
+          cb(mockDataSource),
+        );
+        userRepo.createTransactionRepo.mockReturnValue(userRepo);
+        pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
+
+        // mock
+        userRepo.getUserByPK.mockResolvedValue(userEntity);
+        pointRepo.getPointByPk.mockRejectedValue(new RunTimeException());
+
+        // when & then
+        await expect(service.useUserPoint(command)) //
+          .rejects.toBeInstanceOf(success);
+      });
+
+      it('포인트가 잔액이 부족하면 않으면 사용에 실패한다.', async () => {
+        // given
+        const command = WriteUserPointCommand.from({
+          userId: 1,
+          amount: 100_000,
+        });
+
+        const userEntity = MockEntityGenerator.generateUser({
+          id: command.userId,
+          pointId: 1,
+        });
+        const pointEntity = MockEntityGenerator.generatePoint({
+          id: userEntity.pointId,
+          amount: 90_000,
+        });
+        const success = ConflictStatusException;
+
+        // mock transaction
+        mockDataSource.transaction.mockImplementation(async (cb) =>
+          cb(mockDataSource),
+        );
+        userRepo.createTransactionRepo.mockReturnValue(userRepo);
+        pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
+
+        // mock
+        userRepo.getUserByPK.mockResolvedValue(userEntity);
+        pointRepo.getPointByPk.mockResolvedValue(pointEntity);
+
+        // when & then
+        await expect(service.useUserPoint(command)) //
+          .rejects.toBeInstanceOf(success);
+      });
+    });
+
+    describe('성공한다.', () => {
+      it('유저가 존재하고 유저가 포인트를 가지고 있으면 사용에 성공한다.', async () => {
+        // given
+        const pointId = 1;
+        const command = WriteUserPointCommand.from({
+          userId: 1,
+          amount: 50_000,
+        });
+        const userEntity = MockEntityGenerator.generateUser({
+          id: command.userId,
+          pointId,
+        });
+        const pointEntity = MockEntityGenerator.generatePoint({
+          id: pointId,
+          amount: 100_000,
+        });
+        const success = pointEntity.amount - command.amount;
+
+        // mock transaction
+        mockDataSource.transaction.mockImplementation(async (cb) =>
+          cb(mockDataSource),
+        );
+        userRepo.createTransactionRepo.mockReturnValue(userRepo);
+        pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
+
+        // mock
+        userRepo.getUserByPK.mockResolvedValue(userEntity);
+        pointRepo.getPointByPk.mockResolvedValue(pointEntity);
+        pointRepo.updatePointWithHistory.mockResolvedValue();
+
+        const result = await service.useUserPoint(command);
+
+        // when & then
+        expect(result.amount).toBe(success);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [x] 기능 추가(테스트 추가)
- [ ] 기능 개선(테스트 개선)
- [ ] 기능 삭제(테스트 삭제)
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타

## 1️⃣ 작업내용
> [!NOTE] 구체적인 작업 내용을 정리하면 좋습니다.

1. 유저 포인트 조회 API 구현 완료
2. 유저 포인트 충전 API 구현 완료
3. UserService 구현 완료 및 단위 테스트 추가
   - getUser
   - getUserPoint
   - chargeUserPoint
   - useUserPoint


## 2️⃣ 의사결정 흐름
> [!NOTE] 
> 구현된 코드의 근거나 배경에 대해 설명하면 좋습니다.

### PointEntity 도메인 메서트 추가

```typescript
@Entity('point')
export class PointEntity extends BaseEntity {
  static readonly MIN_POINT = 0;

  @Column('int')
  amount: number;

  /* ================================ Domain Method ================================ */
  chargePoint(addPoint: number): this {
    this.amount += addPoint;
    return this;
  }

  usePoint(subAmount: number): this {
    if (!this.canUsePoint(subAmount)) {
      throw new ConflictStatusException('잔액이 부족합니다.');
    }
    this.amount -= subAmount;
    return this;
  }

  canUsePoint(subAmount: number): boolean {
    return this.amount - subAmount >= PointEntity.MIN_POINT;
  }
}
```
`PointEntity`에 도메인에 필요한 로직을 정의해 비즈니스 로직에서 사용하는 방법을 생각했습니다.
때문에 주요한 검증은 해당 도메인 객체에 구현했습니다.  

### PointRepository
```typescript
export abstract class PointRepository extends BaseRepository<PointEntity> {
  abstract getPointByPk(
    pointId: number,
    options?: FindLockOptions,
  ): Promise<PointEntity>;
  abstract updatePointWithHistory(
    pointId: number,
    param: UpdatePointParam,
  ): Promise<void>;
}
```
`PointRepository`에서는 `PointEntity`와 `PointHistoryEntity`를 관리합니다.
저는 Entity 마다 Repository를 만들어야 한다고 생각하지 않습니다. 도메인의 결합도가 높다면 같이 관리해도 된다고 생각하여 둘을 하나의 Repository로 만들었습니다.
- 근거: Point를 충전하고 사용할 때마다. PointHistory에 내역을 저장해야 합니다. 이것을 분리하는 것이 오히려 복잡도를 올리는 설계라고 생각하여 하나의 Repository로 관리합니다.

### UserService
```typescript
@Injectable()
export class UserService {
  constructor(
    @InjectDataSource()
    private readonly dataSource: DataSource,
    private readonly userRepo: UserRepository,
    private readonly pointRepo: PointRepository,
  ) {}

  // ... 생략
  
  async chargeUserPoint(
    command: WriteUserPointCommand,
  ): Promise<GetUserPointInfo> {
    const { amount: chargeAmount, userId } = command;

    return await this.dataSource
      .transaction(async (txManager) => {
        const txUser = this.userRepo.createTransactionRepo(txManager);
        const txPointRepo = this.pointRepo.createTransactionRepo(txManager);

        const user = await txUser.getUserByPK(userId);
        const point = await txPointRepo.getPointByPk(user.pointId, {
          lock: { mode: 'pessimistic_write_or_fail' },
        });

        point.chargePoint(chargeAmount);

        await txPointRepo.updatePointWithHistory(user.pointId, {
          // TODO: type를 넘기는 건 실수하기 너무 좋음, 개선필요
          type: PointHistoryType.CHARGE,
          amount: point.amount,
        });
        return GetUserPointInfo.of(point);
      })
      .catch((error) => {
        // TODO: 개선이 필요합니다.
        if (error instanceof QueryFailedError && error.message.includes('NOWAIT'))
          throw new ConflictStatusException('포인트 충전 요청 처리중입니다.');
        else throw error;
      });
  }
  
  // ... 생략
```
`UserService#chargeUserPoint`에서는 비관적 락을 사용합니다. 
비관적 락을 사용했지만`pessimistic_write_or_fail`(SELECT ... FOR UPDATE NOWAIT)를 사용해 락에 
걸려 있는 row에 요청이 들어오면 바로 에러가 발생하도록 처리했습니다.

### UserService 단위 테스트

<img width="486" alt="image" src="https://github.com/user-attachments/assets/288a7067-23c7-4830-bb75-4691d2ddef28">

## 3️⃣ 리뷰 포인트
> [!NOTE]
> 명확한 리뷰 포인트나, 리뷰 받고 싶은 코드를 참조하면 좋습니다.

- 단위 테스트 코드를 집중적으로 봐주시면 좋겠습니다.
- Controller > Facade > Service > Repository 계층의 구현이 명확한지 봐주시면 좋겠습니다.

## 4️⃣ 이슈
> [!NOTE] (optional) 공유하고 싶은 이슈나, 코드가 가진 문제(한계)를 알려주세요.

- 

 