### PR TITLE
Feat/공연서비스 예약로직 개선 및 로직 추가

### DIFF
--- a/src/common/exception/exception-type.ts
+++ b/src/common/exception/exception-type.ts
@@ -17,6 +17,8 @@ export enum ApplicationExceptionCode {
   RESOURCE_NOT_FOUND = 'RESOURCE_NOT_FOUND',
   /** 사용불가능한 상태  */
   CONFLICT_STATUS = 'CONFLICT_STATUS',
+  /** 서버 오류 */
+  RUNTIME_ERROR = 'RUNTIME_ERROR',
 }
 
 export const ApplicationExceptionRecord: ApplicationExceptionRecord = {
@@ -33,5 +35,10 @@ export const ApplicationExceptionRecord: ApplicationExceptionRecord = {
   [ApplicationExceptionCode.CONFLICT_STATUS]: {
     message: '사용 불가능한 상태입니다.',
     state: 409,
+  },
+
+  [ApplicationExceptionCode.RUNTIME_ERROR]: {
+    message: 'Runtime 에러',
+    state: 500,
   },
 } as const;

--- a/src/common/exception/index.ts
+++ b/src/common/exception/index.ts
@@ -3,3 +3,4 @@ export * from './application.exception';
 export * from './invalid-parameter.exception';
 export * from './resource-not-found.exception';
 export * from './conflict-status.exception';
+export * from './run-time.exception';

--- a/src/common/exception/run-time.exception.ts
+++ b/src/common/exception/run-time.exception.ts
@@ -1,0 +1,9 @@
+import { ApplicationException } from './application.exception';
+import { ApplicationExceptionCode } from './exception-type';
+
+export class RunTimeException extends ApplicationException {
+  constructor(message?: string) {
+    super(ApplicationExceptionCode.RUNTIME_ERROR);
+    this.message = message;
+  }
+}

--- a/src/domain/concert/performance/application/performance.facade.ts
+++ b/src/domain/concert/performance/application/performance.facade.ts
@@ -5,10 +5,14 @@ import {
   PerformanceService,
   WriteReservationCommand,
 } from '../domain';
+import { UserService } from 'src/domain/user';
 
 @Injectable()
 export class PerformanceFacade {
-  constructor(private readonly performanceService: PerformanceService) {}
+  constructor(
+    private readonly performanceService: PerformanceService,
+    private readonly userService: UserService,
+  ) {}
 
   async getPerformances(concertId: number): Promise<GetPerformancesInfo[]> {
     const performances =
@@ -22,8 +26,9 @@ export class PerformanceFacade {
   }
 
   async reservationSeat(command: WriteReservationCommand): Promise<number> {
-    // TODO: user 검증 로직
+    await this.userService.getUserPoint(command.userId);
 
+    // 객체 지향적으로 UserInfo를 넣게 하자
     const reservationId =
       await this.performanceService.reservationSeat(command);
     // TODO: wait-queue 토큰 만료 로직

--- a/src/domain/concert/performance/domain/model/seat.entity.ts
+++ b/src/domain/concert/performance/domain/model/seat.entity.ts
@@ -1,6 +1,6 @@
-import { Column, Entity, JoinColumn, VersionColumn } from 'typeorm';
+import { Column, Entity, JoinColumn } from 'typeorm';
 
-import { BaseEntity } from 'src/common';
+import { BaseEntity, ConflictStatusException } from 'src/common';
 import { SeatStatus } from './enum';
 
 @Entity('seat')
@@ -21,6 +21,36 @@ export class SeatEntity extends BaseEntity {
   })
   performanceId: number;
 
-  @VersionColumn()
-  version: number;
+  /* ================================ Domain Method ================================ */
+  /**
+   * 좌석이 예약 가능한 상태인지 확인합니다.
+   * @returns {boolean} 예약 가능 여부
+   */
+  isReservable(): boolean {
+    return this.status === SeatStatus.AVAILABLE;
+  }
+
+  /**
+   * 좌석을 예약합니다.
+   * @throws {ConflictStatusException} 좌석이 'Available' 상태가 아니라면 에러를 던집니다.
+   */
+  reserve(): this {
+    if (!this.isReservable()) {
+      throw new ConflictStatusException('좌석을 예약할 수 없는 상태 입니다.');
+    }
+    this.status = SeatStatus.RESERVED;
+    return this;
+  }
+
+  /**
+   * 좌석 예약을 확정합니다.
+   * @throws {ConflictStatusException} 좌석이 'Reserved' 상태가 아니라면 에러를 던집니다.
+   */
+  confirmReservation(): this {
+    if (this.status !== SeatStatus.RESERVED) {
+      throw new ConflictStatusException('좌석 "예약" 상태가 아닙니다.');
+    }
+    this.status = SeatStatus.BOOKED;
+    return this;
+  }
 }

--- a/src/domain/concert/performance/infra/performance-core.repository.ts
+++ b/src/domain/concert/performance/infra/performance-core.repository.ts
@@ -2,9 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
 
-import { PerformanceEntity, SeatEntity, SeatStatus } from '../domain';
-import { PerformanceRepository } from './performance.repository';
 import { ResourceNotFoundException } from 'src/common';
+import { PerformanceEntity, SeatEntity, SeatStatus } from '../domain';
+import {
+  FindLockOptions,
+  PerformanceRepository,
+} from './performance.repository';
 
 @Injectable()
 export class PerformanceCoreRepository extends PerformanceRepository {
@@ -27,13 +30,14 @@ export class PerformanceCoreRepository extends PerformanceRepository {
     });
   }
 
-  override async getPerformanceBy(
+  override async getPerformanceByPk(
     performanceId: number,
   ): Promise<PerformanceEntity> {
     const performance = await this.findOne({
       where: { id: performanceId },
     });
-    if (!performance) throw new ResourceNotFoundException();
+    if (!performance)
+      throw new ResourceNotFoundException('공연이 존재하지 않습니다.');
     return performance;
   }
 
@@ -47,11 +51,14 @@ export class PerformanceCoreRepository extends PerformanceRepository {
     });
   }
 
-  override async getSeatBy(performanceId: number): Promise<SeatEntity> {
+  override async getSeatByPk(
+    seatId: number,
+    options: FindLockOptions = {},
+  ): Promise<SeatEntity> {
     const seat = await this.seatRepo.findOne({
-      where: { performanceId },
+      where: { id: seatId },
+      lock: { ...options.lock },
     });
-
     if (!seat) throw new ResourceNotFoundException();
     return seat;
   }

--- a/src/domain/concert/performance/infra/performance.repository.ts
+++ b/src/domain/concert/performance/infra/performance.repository.ts
@@ -1,14 +1,24 @@
+import { FindOneOptions } from 'typeorm';
 import { BaseRepository } from 'src/common';
 import { PerformanceEntity, SeatEntity, SeatStatus } from '../domain';
 
+export type FindLockOptions = Pick<FindOneOptions, 'lock'>;
+
 export abstract class PerformanceRepository extends BaseRepository<PerformanceEntity> {
   abstract getPerformancesBy(concertId: number): Promise<PerformanceEntity[]>;
-  abstract getPerformanceBy(performanceId: number): Promise<PerformanceEntity>;
+  abstract getPerformanceByPk(
+    performanceId: number,
+  ): Promise<PerformanceEntity>;
 
   abstract getSeatsBy(
     performanceId: number,
     status: SeatStatus,
   ): Promise<SeatEntity[]>;
-  abstract getSeatBy(performanceId: number): Promise<SeatEntity>;
+
+  abstract getSeatByPk(
+    seatId: number,
+    options?: FindLockOptions,
+  ): Promise<SeatEntity>;
+
   abstract updateSeatStatus(seatId: number, status: SeatStatus): Promise<void>;
 }

--- a/test/concert/performance/unit/performance.facade.spec.ts
+++ b/test/concert/performance/unit/performance.facade.spec.ts
@@ -9,15 +9,18 @@ import {
   SeatStatus,
   WriteReservationCommand,
 } from 'src/domain/concert/performance';
+import { GetUserInfo, UserService } from 'src/domain/user';
 import { MockEntityGenerator } from 'test/fixture';
 
 describe('PerformanceFacade', () => {
   let performanceService: MockProxy<PerformanceService>;
+  let userService: MockProxy<UserService>;
   let facade: PerformanceFacade;
 
   beforeEach(() => {
     performanceService = mock<PerformanceService>();
-    facade = new PerformanceFacade(performanceService);
+    userService = mock<UserService>();
+    facade = new PerformanceFacade(performanceService, userService);
   });
 
   describe('getPerformances', () => {
@@ -202,10 +205,17 @@ describe('PerformanceFacade', () => {
           performanceId: 10,
           seatId: 15,
         });
+
+        const userEntity = MockEntityGenerator.generateUser({
+          id: command.userId,
+          pointId: 10,
+        });
+        const userInfo = GetUserInfo.of(userEntity);
         const newReservationId = 1;
         const success = newReservationId;
 
         // mock
+        userService.getUser.mockResolvedValue(userInfo);
         performanceService.reservationSeat.mockResolvedValue(newReservationId);
 
         // when
@@ -216,7 +226,7 @@ describe('PerformanceFacade', () => {
       });
 
       describe('만료한다.', () => {
-        it.skip('TODO: 좌석 임시예약에 성공하면 토큰이 만료된다.', async () => {
+        it.skip('좌석 임시예약에 성공하면 토큰이 만료된다.', async () => {
           // given
           // mock
           // when

--- a/test/concert/performance/unit/performance.service.spec.ts
+++ b/test/concert/performance/unit/performance.service.spec.ts
@@ -57,7 +57,6 @@ describe('PerformanceService', () => {
         performanceRepo.getPerformancesBy.mockResolvedValue(
           performanceEntities,
         );
-
         // when
         const results = await service.getPerformances(concertId);
 
@@ -120,8 +119,15 @@ describe('PerformanceService', () => {
         });
         const success = ResourceNotFoundException;
 
+        // mock transaction
+        mockDataSource.transaction.mockImplementation(async (cb) =>
+          cb(mockDataSource),
+        );
+        performanceRepo.createTransactionRepo.mockReturnValue(performanceRepo);
+        reservationRepo.createTransactionRepo.mockReturnValue(reservationRepo);
+
         // mock
-        performanceRepo.getSeatBy.mockRejectedValue(
+        performanceRepo.getSeatByPk.mockRejectedValue(
           new ResourceNotFoundException(),
         );
 
@@ -141,11 +147,21 @@ describe('PerformanceService', () => {
           command.seatId,
           command.performanceId,
         );
+
         seatEntity.status = SeatStatus.RESERVED;
         const success = ConflictStatusException;
 
+        // mock transaction
+        mockDataSource.transaction.mockImplementation(async (cb) =>
+          cb(mockDataSource),
+        );
+        performanceRepo.createTransactionRepo.mockReturnValue(performanceRepo);
+        reservationRepo.createTransactionRepo.mockReturnValue(reservationRepo);
+
         // mock
-        performanceRepo.getSeatBy.mockResolvedValue(seatEntity);
+        performanceRepo.getSeatByPk.mockRejectedValue(
+          new ConflictStatusException(),
+        );
 
         // when & then
         await expect(service.reservationSeat(command)) //
@@ -166,8 +182,15 @@ describe('PerformanceService', () => {
         seatEntity.status = SeatStatus.BOOKED;
         const success = ConflictStatusException;
 
+        // mock transaction
+        mockDataSource.transaction.mockImplementation(async (cb) =>
+          cb(mockDataSource),
+        );
+        performanceRepo.createTransactionRepo.mockReturnValue(performanceRepo);
+        reservationRepo.createTransactionRepo.mockReturnValue(reservationRepo);
+
         // mock
-        performanceRepo.getSeatBy.mockResolvedValue(seatEntity);
+        performanceRepo.getSeatByPk.mockResolvedValue(seatEntity);
 
         // when & then
         await expect(service.reservationSeat(command)) //
@@ -193,7 +216,7 @@ describe('PerformanceService', () => {
         const success = newReservationId;
 
         // mock
-        performanceRepo.getSeatBy.mockResolvedValue(seatEntity);
+        performanceRepo.getSeatByPk.mockResolvedValue(seatEntity);
 
         // mock transaction
         mockDataSource.transaction.mockImplementation(async (cb) =>


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [x] 기능 추가(테스트 추가)
- [x] 기능 개선(테스트 개선)
- [ ] 기능 삭제(테스트 삭제)
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> [!NOTE] 
> 구체적인 작업 내용을 정리하면 좋습니다.

1. PerformanceFacade#reservationSeat 유저 검증 로직 추가와 단위테스트 추가
2. PerformanceService#reservationSeat Lock 로직 변경
3. SeatEntity에 도메인 메서드 추가

## 2️⃣ 의사결정 흐름
> [!NOTE] 구현된 코드의 근거나 배경에 대해 설명하면 좋습니다.

### `SeatEntity` 메서드 추가
```
import { Column, Entity, JoinColumn } from 'typeorm';

import { BaseEntity, ConflictStatusException } from 'src/common';
import { SeatStatus } from './enum';

@Entity('seat')
export class SeatEntity extends BaseEntity {
  @Column('int')
  position: number;

  @Column('int')
  amount: number;

  @Column()
  status: SeatStatus;

  @Column('int')
  @JoinColumn({
    name: 'performanceId',
    foreignKeyConstraintName: 'fk_seat_performanceId',
  })
  performanceId: number;

  /* ================================ Domain Method ================================ */
  /**
   * 좌석이 예약 가능한 상태인지 확인합니다.
   * @returns {boolean} 예약 가능 여부
   */
  isReservable(): boolean {
    return this.status === SeatStatus.AVAILABLE;
  }

  /**
   * 좌석을 예약합니다.
   * @throws {ConflictStatusException} 좌석이 'Available' 상태가 아니라면 에러를 던집니다.
   */
  reserve(): this {
    if (!this.isReservable()) {
      throw new ConflictStatusException('좌석을 예약할 수 없는 상태 입니다.');
    }
    this.status = SeatStatus.RESERVED;
    return this;
  }

  /**
   * 좌석 예약을 확정합니다.
   * @throws {ConflictStatusException} 좌석이 'Reserved' 상태가 아니라면 에러를 던집니다.
   */
  confirmReservation(): this {
    if (this.status !== SeatStatus.RESERVED) {
      throw new ConflictStatusException('좌석 "예약" 상태가 아닙니다.');
    }
    this.status = SeatStatus.BOOKED;
    return this;
  }
}
```

###  `PerformanceService#reservationSeat`에 비관적 락으로 수정
```
@Injectable()
export class PerformanceService {
  constructor(
    @InjectDataSource()
    private readonly dataSource: DataSource,
    private readonly performanceRepo: PerformanceRepository,
    private readonly reservationRepo: ReservationRepository,
  ) {}

  // ... 생략
  /**
   * 예약 과정에서 좌석 상태변경은 비관적락 + NOWAIT 옵션을 사용한다.
   * - `SELECT * FROM table WHERE id = 5 FOR UPDATE NOWAIT;`
   * - 메서드명 reserveSeat으로 변경하자
   * @param command
   * @returns
   */
  async reservationSeat(command: WriteReservationCommand): Promise<number> {
    return await this.dataSource
      .transaction(async (txManager) => {
        const txPerformanceRepo =
          this.performanceRepo.createTransactionRepo(txManager);
        const txReservationRepo =
          this.reservationRepo.createTransactionRepo(txManager);

        // Note: 비관적 락 + nowait 모드로 커넥션을 획득하지 못하면 즉시 에러처리한다.
        const seat = await txPerformanceRepo.getSeatByPk(command.seatId, {
          lock: { mode: 'pessimistic_write_or_fail' },
        });
        seat.reserve();

        await txPerformanceRepo.updateSeatStatus(seat.id, seat.status);
        const reservationId = await txReservationRepo.insertOne({
          seatId: command.seatId,
          userId: command.userId,
        });
        return reservationId;
      })
      .catch((error) => {
        if (
          error instanceof QueryFailedError &&
          error.message.includes('NOWAIT')
        )
          throw new ConflictStatusException('이미 선점된 좌석입니다.');
        else throw error;
      });
  }
}

```
- 비관적 락을 사용하지만 pessimistic_write_or_fail 모드를 사용해 동시에 좌석 요청이 들어오는 경우 즉시 실패 하도록 설계 했습니다.

## 3️⃣ 리뷰 포인트
> [!NOTE] 명확한 리뷰 포인트나, 리뷰 받고 싶은 코드를 참조하면 좋습니다.

- 좌석 예약의 핵심 로직인 `SeatEntity`와 `PerformanceService#reservationSeat`를 중점으로 봐주시면 좋겠습니다.

## 4️⃣ 이슈
> [!NOTE] (optional) 공유하고 싶은 이슈나, 코드가 가진 문제(한계)를 알려주세요.

-

 