### PR TITLE
refator/커스텀에러-개선

### DIFF
--- a/src/common/exception/application.exception.ts
+++ b/src/common/exception/application.exception.ts
@@ -7,19 +7,14 @@ import {
 export abstract class ApplicationException extends Error {
   /** 에러 메시지 */
   message: string;
-  /** 에러 상태값으로 HttpCode와 대응한다. */
-  readonly state: number;
 
   constructor(readonly code: ApplicationExceptionCode) {
     super();
     Error.captureStackTrace(this);
 
-    const { message, state } = ApplicationExceptionRecord[this.code];
+    const { message } = ApplicationExceptionRecord[this.code];
     this.message = message;
-    this.state = state;
   }
 
-  toHttpException() {
-    return new HttpException(this.message, this.state);
-  }
+  abstract toHttpException(): HttpException;
 }

--- a/src/common/exception/conflict-status.exception.ts
+++ b/src/common/exception/conflict-status.exception.ts
@@ -1,3 +1,4 @@
+import { ConflictException, HttpException } from '@nestjs/common';
 import { ApplicationException } from './application.exception';
 import { ApplicationExceptionCode } from './exception-type';
 
@@ -5,5 +6,9 @@ export class ConflictStatusException extends ApplicationException {
   constructor(message?: string) {
     super(ApplicationExceptionCode.CONFLICT_STATUS);
     this.message = message;
+  }
+
+  toHttpException(): HttpException {
+    throw new ConflictException(this.message);
   }
 }

--- a/src/common/exception/exception-type.ts
+++ b/src/common/exception/exception-type.ts
@@ -1,9 +1,6 @@
 type ApplicationExceptionRecordValue = {
   /** 에러 메시지, 응답에도 사용된다. */
   message: string;
-
-  /** http 에러 상태 코드 */
-  state: number;
 };
 type ApplicationExceptionRecord = Record<
   ApplicationExceptionCode,
@@ -24,21 +21,17 @@ export enum ApplicationExceptionCode {
 export const ApplicationExceptionRecord: ApplicationExceptionRecord = {
   [ApplicationExceptionCode.INVALID_PARAMETER]: {
     message: '잘못된 값을 사용하고 있습니다.',
-    state: 400,
   },
 
   [ApplicationExceptionCode.RESOURCE_NOT_FOUND]: {
     message: '자원이 존재하지 않습니다.',
-    state: 404,
   },
 
   [ApplicationExceptionCode.CONFLICT_STATUS]: {
     message: '사용 불가능한 상태입니다.',
-    state: 409,
   },
 
   [ApplicationExceptionCode.RUNTIME_ERROR]: {
-    message: 'Runtime 에러',
-    state: 500,
+    message: 'Runtime 에러입니다.',
   },
 } as const;

--- a/src/common/exception/invalid-parameter.exception.ts
+++ b/src/common/exception/invalid-parameter.exception.ts
@@ -1,3 +1,4 @@
+import { BadRequestException, HttpException } from '@nestjs/common';
 import { ApplicationException } from './application.exception';
 import { ApplicationExceptionCode } from './exception-type';
 
@@ -5,5 +6,9 @@ export class InvalidParameterException extends ApplicationException {
   constructor(message?: string) {
     super(ApplicationExceptionCode.INVALID_PARAMETER);
     this.message = message;
+  }
+
+  toHttpException(): HttpException {
+    throw new BadRequestException(this.message);
   }
 }

--- a/src/common/exception/resource-not-found.exception.ts
+++ b/src/common/exception/resource-not-found.exception.ts
@@ -1,3 +1,4 @@
+import { HttpException, NotFoundException } from '@nestjs/common';
 import { ApplicationException } from './application.exception';
 import { ApplicationExceptionCode } from './exception-type';
 
@@ -5,5 +6,9 @@ export class ResourceNotFoundException extends ApplicationException {
   constructor(message?: string) {
     super(ApplicationExceptionCode.RESOURCE_NOT_FOUND);
     this.message = message;
+  }
+
+  toHttpException(): HttpException {
+    return new NotFoundException(this.message);
   }
 }

--- a/src/common/exception/run-time.exception.ts
+++ b/src/common/exception/run-time.exception.ts
@@ -1,3 +1,4 @@
+import { HttpException, InternalServerErrorException } from '@nestjs/common';
 import { ApplicationException } from './application.exception';
 import { ApplicationExceptionCode } from './exception-type';
 
@@ -5,5 +6,9 @@ export class RunTimeException extends ApplicationException {
   constructor(message?: string) {
     super(ApplicationExceptionCode.RUNTIME_ERROR);
     this.message = message;
+  }
+
+  toHttpException(): HttpException {
+    throw new InternalServerErrorException();
   }
 }


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [ ] 기능 추가(테스트 추가)
- [x] 기능 개선(테스트 개선)
- [ ] 기능 삭제(테스트 삭제)
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> [!NOTE] 구체적인 작업 내용을 정리하면 좋습니다.

1. `ApplicationException`이 HttpStatus Code를 알지 못하도록 코드를 수정

## 2️⃣ 의사결정 흐름
> [!NOTE] 
> 구현된 코드의 근거나 배경에 대해 설명하면 좋습니다.

멘토링 청강중 들었던 ApplicationException 에서 HttpStats를 왜 알아야 하는가에 대한 얘기를 들었습니다.   
- 컨트롤러는 Rest API만 지원하는 것이 아닌 GQL 또는 grpc 같은 다른 엔트리 포인트를 구현할 수 있다

개선 사항
1. `ApplicationException`에서 HttpStats를 제거
2. `ApplicationException#toHttpException`를 추상 메서드로 변경 
3. `ApplicationException`을 상속하는 자식 클래스는 `toHttpException`에서 적합한 에러 변환 로직을 구현 합니다.

Q) 이후에 grpc 등을 지원하게 된다면?
A) ApplicationException#toGrpcException을 추상클래스로 사용해 에러 처리가 가능하도록 합니다.
```ts
export abstract class ApplicationException extends Error {
  /** 에러 메시지 */
  message: string;

  constructor(readonly code: ApplicationExceptionCode) {
    super();
    Error.captureStackTrace(this);

    const { message } = ApplicationExceptionRecord[this.code];
    this.message = message;
  }

  abstract toHttpException(): HttpException;

  abstract toGrpcException(): GrpcException;
}

```

## 3️⃣ 리뷰 포인트
> [!NOTE] 명확한 리뷰 포인트나, 리뷰 받고 싶은 코드를 참조하면 좋습니다.

- 

## 4️⃣ 이슈
> [!NOTE] (optional) 공유하고 싶은 이슈나, 코드가 가진 문제(한계)를 알려주세요.

-

 