### PR TITLE
Refator/PaymentFacade#payment 트랜잭션적용 

### DIFF
--- a/src/domain/concert/performance/domain/performance.service.ts
+++ b/src/domain/concert/performance/domain/performance.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { InjectDataSource } from '@nestjs/typeorm';
+import { InjectEntityManager } from '@nestjs/typeorm';
 import { ConflictStatusException } from 'src/common';
-import { DataSource, QueryFailedError } from 'typeorm';
+import { EntityManager, QueryFailedError } from 'typeorm';
 import { PerformanceRepository, ReservationRepository } from '../infra';
 import {
   GetPerformancesInfo,
@@ -13,10 +13,9 @@ import { SeatStatus } from './model';
 @Injectable()
 export class PerformanceService {
   constructor(
-    @InjectDataSource()
-    private readonly dataSource: DataSource,
     private readonly performanceRepo: PerformanceRepository,
     private readonly reservationRepo: ReservationRepository,
+    @InjectEntityManager() private readonly manager: EntityManager,
   ) {}
 
   async getPerformances(concertId: number): Promise<GetPerformancesInfo[]> {
@@ -46,7 +45,7 @@ export class PerformanceService {
    * @returns
    */
   async reserveSeat(command: WriteReservationCommand): Promise<number> {
-    return await this.dataSource
+    return await this.manager
       .transaction(async (txManager) => {
         const txPerformanceRepo =
           this.performanceRepo.createTransactionRepo(txManager);
@@ -88,7 +87,7 @@ export class PerformanceService {
   }
 
   async bookingSeat(seatId: number): Promise<void> {
-    await this.dataSource.transaction(async (txManager) => {
+    await this.manager.transaction(async (txManager) => {
       const txPerformanceRepo =
         this.performanceRepo.createTransactionRepo(txManager);
       const txReservationRepo =

--- a/src/domain/concert/performance/domain/performance.service.ts
+++ b/src/domain/concert/performance/domain/performance.service.ts
@@ -5,6 +5,7 @@ import { EntityManager, QueryFailedError } from 'typeorm';
 import { PerformanceRepository, ReservationRepository } from '../infra';
 import {
   GetPerformancesInfo,
+  GetReservationInfo,
   GetSeatsInfo,
   WriteReservationCommand,
 } from './dto';
@@ -76,33 +77,46 @@ export class PerformanceService {
       });
   }
 
-  async getSeatReservation(reservationId: number, userId: number) {
-    const reservation = await this.reservationRepo.getReservationBy({
-      id: reservationId,
-      userId,
-    });
-    if (!reservation.isRequest)
-      throw new ConflictStatusException('"예약신청" 상태가 아닙니다.');
-    return reservation;
+  getSeatReservation(
+    reservationId: number,
+    userId: number,
+  ): (manager?: EntityManager) => Promise<GetReservationInfo> {
+    return async (manager: EntityManager = null) => {
+      const txReservationRepo = manager
+        ? this.reservationRepo.createTransactionRepo(manager)
+        : this.reservationRepo;
+
+      const reservation = await txReservationRepo.getReservationBy({
+        id: reservationId,
+        userId,
+      });
+      if (!reservation.isRequest)
+        throw new ConflictStatusException('"예약신청" 상태가 아닙니다.');
+      return GetReservationInfo.of(reservation);
+    };
   }
 
-  async bookingSeat(seatId: number): Promise<void> {
-    await this.manager.transaction(async (txManager) => {
-      const txPerformanceRepo =
-        this.performanceRepo.createTransactionRepo(txManager);
-      const txReservationRepo =
-        this.reservationRepo.createTransactionRepo(txManager);
+  bookingSeat(seatId: number): (manager?: EntityManager) => Promise<void> {
+    return async (manager: EntityManager = this.manager) => {
+      await manager.transaction(async (txManager) => {
+        const txPerformanceRepo =
+          this.performanceRepo.createTransactionRepo(txManager);
+        const txReservationRepo =
+          this.reservationRepo.createTransactionRepo(txManager);
 
-      const seat = await txPerformanceRepo.getSeatByPk(seatId);
-      seat.booking();
-      await txPerformanceRepo.updateSeatStatus(seat.id, seat.status);
+        const seat = await txPerformanceRepo.getSeatByPk(seatId);
+        seat.booking();
+        await txPerformanceRepo.updateSeatStatus(seat.id, seat.status);
 
-      const reservation = await txReservationRepo.getReservationBy({ seatId });
-      reservation.confirm();
-      await txReservationRepo.updateReservationStatus(
-        reservation.id,
-        reservation.status,
-      );
-    });
+        const reservation = await txReservationRepo.getReservationBy({
+          seatId,
+        });
+        reservation.confirm();
+        await txReservationRepo.updateReservationStatus(
+          reservation.id,
+          reservation.status,
+        );
+      });
+    };
   }
 }

--- a/src/domain/payment/application/payment.facade.ts
+++ b/src/domain/payment/application/payment.facade.ts
@@ -4,6 +4,8 @@ import { UserService, WriteUserPointCommand } from 'src/domain/user';
 import { GetPaymentInfo, WritePaymentCommand } from '../doamin';
 import { PaymentService } from '../doamin/payment.service';
 import { WritePaymentCriteria } from './dto';
+import { EntityManager } from 'typeorm';
+import { InjectEntityManager } from '@nestjs/typeorm';
 
 @Injectable()
 export class PaymentFacade {
@@ -11,37 +13,40 @@ export class PaymentFacade {
     private readonly paymentService: PaymentService,
     private readonly performanceService: PerformanceService,
     private readonly userService: UserService,
+    @InjectEntityManager() private readonly manager: EntityManager,
   ) {}
 
-  // TODO: 트랜잭션을 여기서 열어야 하나?
   async payment(criteria: WritePaymentCriteria): Promise<GetPaymentInfo> {
     const { reservationId, userId } = criteria;
-    // 예약 확인
-    const reservation = await this.performanceService.getSeatReservation(
-      reservationId,
-      userId,
-    );
-    const payPrice = reservation.price;
 
-    // 포인트 사용
-    await this.userService.useUserPoint(
-      WriteUserPointCommand.from({
-        userId,
-        amount: payPrice,
-      }),
-    );
-
-    // 좌석 상태 변경과 예약 확정
-    await this.performanceService.bookingSeat(reservation.seatId);
-
-    // 결제 생성
-    const paymentInfo = await this.paymentService.payment(
-      WritePaymentCommand.from({
-        userId,
+    return await this.manager.transaction(async (txManager) => {
+      // 예약 확인
+      const reservation = await this.performanceService.getSeatReservation(
         reservationId,
-        payPrice,
-      }),
-    );
-    return paymentInfo;
+        userId,
+      )(txManager);
+      const payPrice = reservation.price;
+
+      // 포인트 사용
+      await this.userService.useUserPoint(
+        WriteUserPointCommand.from({
+          userId,
+          amount: payPrice,
+        }),
+      )(txManager);
+
+      // 좌석 상태 변경과 예약 확정
+      await this.performanceService.bookingSeat(reservation.seatId)(txManager);
+
+      // 결제 생성
+      const paymentInfo = await this.paymentService.payment(
+        WritePaymentCommand.from({
+          userId,
+          reservationId,
+          payPrice,
+        }),
+      )(txManager);
+      return paymentInfo;
+    });
   }
 }

--- a/src/domain/payment/doamin/payment.service.ts
+++ b/src/domain/payment/doamin/payment.service.ts
@@ -1,18 +1,26 @@
 import { Injectable } from '@nestjs/common';
 import { PaymentRepository } from '../infra';
 import { GetPaymentInfo, WritePaymentCommand } from './dto';
-import { EntityManager } from 'typeorm';
 import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
 
 @Injectable()
 export class PaymentService {
   constructor(
-    private readonly paymentRepo: PaymentRepository,
     @InjectEntityManager() private readonly manager: EntityManager,
+    private readonly paymentRepo: PaymentRepository,
   ) {}
 
-  async payment(command: WritePaymentCommand): Promise<GetPaymentInfo> {
-    const payment = await this.paymentRepo.savePayment(command);
-    return GetPaymentInfo.of(payment);
+  payment(
+    command: WritePaymentCommand,
+  ): (manager?: EntityManager) => Promise<GetPaymentInfo> {
+    return async (manager: EntityManager = null) => {
+      const txPaymentRepo = manager
+        ? this.paymentRepo.createTransactionRepo(manager)
+        : this.paymentRepo;
+
+      const payment = await txPaymentRepo.savePayment(command);
+      return GetPaymentInfo.of(payment);
+    };
   }
 }

--- a/src/domain/payment/doamin/payment.service.ts
+++ b/src/domain/payment/doamin/payment.service.ts
@@ -1,10 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { PaymentRepository } from '../infra';
 import { GetPaymentInfo, WritePaymentCommand } from './dto';
+import { EntityManager } from 'typeorm';
+import { InjectEntityManager } from '@nestjs/typeorm';
 
 @Injectable()
 export class PaymentService {
-  constructor(private readonly paymentRepo: PaymentRepository) {}
+  constructor(
+    private readonly paymentRepo: PaymentRepository,
+    @InjectEntityManager() private readonly manager: EntityManager,
+  ) {}
 
   async payment(command: WritePaymentCommand): Promise<GetPaymentInfo> {
     const payment = await this.paymentRepo.savePayment(command);

--- a/src/domain/user/domain/user.service.ts
+++ b/src/domain/user/domain/user.service.ts
@@ -1,19 +1,18 @@
 import { Injectable } from '@nestjs/common';
-import { InjectDataSource } from '@nestjs/typeorm';
-import { DataSource, QueryFailedError } from 'typeorm';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager, QueryFailedError } from 'typeorm';
 
-import { GetUserInfo, GetUserPointInfo, WriteUserPointCommand } from './dto';
-import { PointRepository, UserRepository } from '../infra';
-import { PointHistoryType } from './model/enum';
 import { ConflictStatusException } from 'src/common';
+import { PointRepository, UserRepository } from '../infra';
+import { GetUserInfo, GetUserPointInfo, WriteUserPointCommand } from './dto';
+import { PointHistoryType } from './model/enum';
 
 @Injectable()
 export class UserService {
   constructor(
-    @InjectDataSource()
-    private readonly dataSource: DataSource,
     private readonly userRepo: UserRepository,
     private readonly pointRepo: PointRepository,
+    @InjectEntityManager() private readonly manager: EntityManager,
   ) {}
 
   async getUser(userId: number): Promise<GetUserInfo> {
@@ -32,7 +31,7 @@ export class UserService {
   ): Promise<GetUserPointInfo> {
     const { amount: chargeAmount, userId } = command;
 
-    return await this.dataSource
+    return await this.manager
       .transaction(async (txManager) => {
         const txUser = this.userRepo.createTransactionRepo(txManager);
         const txPointRepo = this.pointRepo.createTransactionRepo(txManager);
@@ -67,7 +66,7 @@ export class UserService {
   ): Promise<GetUserPointInfo> {
     const { amount: chargeAmount, userId } = command;
 
-    return await this.dataSource
+    return await this.manager
       .transaction(async (txManager) => {
         const txUser = this.userRepo.createTransactionRepo(txManager);
         const txPointRepo = this.pointRepo.createTransactionRepo(txManager);

--- a/test/user/unit/user.service.spec.ts
+++ b/test/user/unit/user.service.spec.ts
@@ -1,32 +1,32 @@
 import { type MockProxy, mock } from 'jest-mock-extended';
-import { DataSource } from 'typeorm';
+import { EntityManager } from 'typeorm';
 
 import {
+  ConflictStatusException,
+  ResourceNotFoundException,
+  RunTimeException,
+} from 'src/common';
+import {
+  GetUserInfo,
   GetUserPointInfo,
   PointRepository,
   UserRepository,
   UserService,
   WriteUserPointCommand,
 } from 'src/domain/user';
-import {
-  ConflictStatusException,
-  ResourceNotFoundException,
-  RunTimeException,
-} from 'src/common';
 import { MockEntityGenerator } from 'test/fixture';
-import { GetUserInfo } from 'src/domain/user';
 
 describe('UserService', () => {
-  let mockDataSource: MockProxy<DataSource>;
+  let mockManamer: MockProxy<EntityManager>;
   let userRepo: MockProxy<UserRepository>;
   let pointRepo: MockProxy<PointRepository>;
   let service: UserService;
 
   beforeEach(() => {
-    mockDataSource = mock<DataSource>();
+    mockManamer = mock<EntityManager>();
     userRepo = mock<UserRepository>();
     pointRepo = mock<PointRepository>();
-    service = new UserService(mockDataSource, userRepo, pointRepo);
+    service = new UserService(userRepo, pointRepo, mockManamer);
   });
 
   describe('getUser', () => {
@@ -133,8 +133,8 @@ describe('UserService', () => {
         const success = ResourceNotFoundException;
 
         // mock transaction
-        mockDataSource.transaction.mockImplementation(async (cb) =>
-          cb(mockDataSource),
+        mockManamer.transaction.mockImplementation(async (cb) =>
+          cb(mockManamer),
         );
         userRepo.createTransactionRepo.mockReturnValue(userRepo);
         pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
@@ -160,8 +160,8 @@ describe('UserService', () => {
         const success = RunTimeException;
 
         // mock transaction
-        mockDataSource.transaction.mockImplementation(async (cb) =>
-          cb(mockDataSource),
+        mockManamer.transaction.mockImplementation(async (cb) =>
+          cb(mockManamer),
         );
         userRepo.createTransactionRepo.mockReturnValue(userRepo);
         pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
@@ -195,8 +195,8 @@ describe('UserService', () => {
         const success = pointEntity.amount + command.amount;
 
         // mock transaction
-        mockDataSource.transaction.mockImplementation(async (cb) =>
-          cb(mockDataSource),
+        mockManamer.transaction.mockImplementation(async (cb) =>
+          cb(mockManamer),
         );
         userRepo.createTransactionRepo.mockReturnValue(userRepo);
         pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
@@ -229,8 +229,8 @@ describe('UserService', () => {
         const success = RunTimeException;
 
         // mock transaction
-        mockDataSource.transaction.mockImplementation(async (cb) =>
-          cb(mockDataSource),
+        mockManamer.transaction.mockImplementation(async (cb) =>
+          cb(mockManamer),
         );
         userRepo.createTransactionRepo.mockReturnValue(userRepo);
         pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
@@ -262,8 +262,8 @@ describe('UserService', () => {
         const success = ConflictStatusException;
 
         // mock transaction
-        mockDataSource.transaction.mockImplementation(async (cb) =>
-          cb(mockDataSource),
+        mockManamer.transaction.mockImplementation(async (cb) =>
+          cb(mockManamer),
         );
         userRepo.createTransactionRepo.mockReturnValue(userRepo);
         pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
@@ -297,8 +297,8 @@ describe('UserService', () => {
         const success = pointEntity.amount - command.amount;
 
         // mock transaction
-        mockDataSource.transaction.mockImplementation(async (cb) =>
-          cb(mockDataSource),
+        mockManamer.transaction.mockImplementation(async (cb) =>
+          cb(mockManamer),
         );
         userRepo.createTransactionRepo.mockReturnValue(userRepo);
         pointRepo.createTransactionRepo.mockReturnValue(pointRepo);
@@ -308,7 +308,7 @@ describe('UserService', () => {
         pointRepo.getPointByPk.mockResolvedValue(pointEntity);
         pointRepo.updatePointWithHistory.mockResolvedValue();
 
-        const result = await service.useUserPoint(command);
+        const result = await service.useUserPoint(command)();
 
         // when & then
         expect(result.amount).toBe(success);


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [ ] 기능 추가(테스트 추가)
- [x] 기능 개선(테스트 개선)
- [ ] 기능 삭제(테스트 삭제)
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> [!NOTE] 
> 구체적인 작업 내용을 정리하면 좋습니다.

1. PaymentFacade#payment 결제 로직에 트랜잭션 적용 

## 2️⃣ 의사결정 흐름
> [!NOTE] 
> 구현된 코드의 근거나 배경에 대해 설명하면 좋습니다.

### `PaymentFacade#payment` 결제 로직에 트랜잭션 적용 
paymeny 메서드에서 트랜잭션을 적용하려면 typeorm의 트랜잭션을 Facade에서 열어야 합니다.
그리고 해당 트랜잭션을 하위 계층에 전퍄하도록 해야합니다.

3가지 방법을 고민했습니다.
1) EntityManager을 optional로 받는 매개변수를 사용하는 방법
2) EntityManager를 커링을 사용하는 방법
3) AsyncLocalStroge를 사용해서 EntityManager를 하위 계층에 전달하는 방법

위의 방법중 1번은 개발자의 파라미터 입력 누락등의 이유로 안전하지 않다고 판단되어 먼저 제외 했습니다.
그리고 남은 2번과 3번 방법을 둘다 구현하고, 테스트를 수행 후 2번 방법을 사용하기로 결정했습니다.

- 2) EntityManager를 커링을 사용하는 방법
![image](https://github.com/user-attachments/assets/3c9cb3d9-988e-4137-ac95-331f43cff3b8)

- 3) AsyncLocalStroge를 사용해서 EntityManager를 하위 계층에 전달하는 방법
![image](https://github.com/user-attachments/assets/1cf06c72-ebf2-4e8b-91bc-524a8d690b8d)

#### 2번을 선택한 이유
3번을 구현했을때 가장 큰 단점은 AsyncLocalStroge를 모른다면 동작을 예상하기 어렵다는 점과 AsyncLocalStroge라는 의존성이 있어야 한다는 것이였습니다. 반면 2번의 경우 개발자의 트랜잭션 파라미터 입력 누락을 효과적으로 방지할 수 있고 또한 외부 의존 없이 언어에서 지원하는 문법으로 문제를 해결할 수 있다는 장점이 있습니다.

## 3️⃣ 리뷰 포인트
> [!NOTE] 
> 명확한 리뷰 포인트나, 리뷰 받고 싶은 코드를 참조하면 좋습니다.

- `PaymentFacade#payment` 구현 로직

## 4️⃣ 이슈
> [!NOTE] (optional) 
> 공유하고 싶은 이슈나, 코드가 가진 문제(한계)를 알려주세요.

### 2) EntityManager를 커링을 사용하는 방법의 단점 
물론 단점도 있었습니다. 커링을 잘 사용하지 않다보니 서비스에서 커링 함수를 리턴하는 방식이 어딘가 어색했고, 또한 트랜잭션에 사용하는 서비스 메서드만 커링 함수를 리턴하도록 구현했는데 일관성을 위해 모든 코드를 변경하고 싶지 않았고 결과적으로 2가지 리턴 방식이 혼용되 어 있는 문제가 있습니다.


 