### PR TITLE
Feat/대기큐 만료로직 구현

### DIFF
--- a/docs/4-ERD-정의서.md
+++ b/docs/4-ERD-정의서.md
@@ -15,7 +15,7 @@ erDiagram
         QueueStatus status
         datetime createdAt
         datetime expireAt
-        datetime activeAt
+        datetime activedAt
     }
 
     %% 콘서트 예약 서비스

--- a/migrations/local/1729215044973-init.ts
+++ b/migrations/local/1729215044973-init.ts
@@ -83,7 +83,8 @@ export class Init1729215044973 implements MigrationInterface {
             \`userId\` int NOT NULL,
             \`status\` varchar(255) NOT NULL,
             \`activeExpireAt\` datetime DEFAULT NULL,
-            \`activeAt\` datetime DEFAULT NULL,
+            \`activedAt\` datetime DEFAULT NULL,
+            \`activeFirstAccessAt\` datetime DEFAULT NULL,
             PRIMARY KEY (\`id\`)
           ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
         `);

--- a/src/domain/auth/guard/base-jwt.guard.ts
+++ b/src/domain/auth/guard/base-jwt.guard.ts
@@ -1,4 +1,8 @@
-import { CanActivate, ExecutionContext } from '@nestjs/common';
+import {
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { UserRequest } from 'src/common';
 
 export class BaseJwtGuard implements CanActivate {
@@ -13,10 +17,12 @@ export class BaseJwtGuard implements CanActivate {
 
   protected getJwt(request: UserRequest): string | null {
     const authorization: string | undefined = request.headers['authorization']; // authorization
-    return (
+    const jwt =
       authorization &&
       authorization.startsWith('Bearer') &&
-      authorization.split(' ')[1]
-    );
+      authorization.split(' ')[1];
+
+    if (!jwt) throw new UnauthorizedException();
+    return jwt;
   }
 }

--- a/src/domain/auth/guard/jwt.guard.ts
+++ b/src/domain/auth/guard/jwt.guard.ts
@@ -4,29 +4,37 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 
+import { UserInfo, UserRequest } from 'src/common';
+import { QueueService } from 'src/domain/queue';
 import { AuthService } from '../auth.service';
 import { BaseJwtGuard } from './base-jwt.guard';
-import { UserInfo, UserRequest } from 'src/common';
 
 @Injectable()
 export class JwtGuard extends BaseJwtGuard {
-  constructor(private readonly authService: AuthService) {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly queueService: QueueService,
+  ) {
     super();
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = this.getRequest<UserRequest>(context);
     const jwt = this.getJwt(request);
-    if (!jwt) throw new UnauthorizedException();
-
     const payload = this.authService.decodeToken(jwt);
     if (!payload) throw new UnauthorizedException();
+
+    // 큐 만료 체크
+    const queueInfo = await this.queueService.findActiveQueue(payload.queueUid);
+    if (!queueInfo) throw new UnauthorizedException();
+    if (queueInfo.activeFirstAccessAt < new Date())
+      throw new UnauthorizedException();
+
     const userInfo: UserInfo = {
       userId: payload.userId,
       queueUid: payload.queueUid,
       jwt,
     };
-
     request.user = userInfo;
     return true;
   }

--- a/src/domain/concert/performance/performance.module.ts
+++ b/src/domain/concert/performance/performance.module.ts
@@ -10,9 +10,10 @@ import {
 } from './infra';
 import { PerformanceFacade } from './application';
 import { UserModule } from 'src/domain/user';
+import { QueueModule } from 'src/domain/queue';
 
 @Module({
-  imports: [UserModule],
+  imports: [UserModule, QueueModule],
   controllers: [PerformanceController],
   providers: [
     PerformanceFacade,

--- a/src/domain/queue/application/queue.facade.ts
+++ b/src/domain/queue/application/queue.facade.ts
@@ -39,6 +39,6 @@ export class QueueFacade {
   }
 
   async changeQueueExpireStatus(): Promise<void> {
-    await this.queueService.changeExpireStatusQueues();
+    await this.queueService.changeAllExpireStatus();
   }
 }

--- a/src/domain/queue/domain/dto/info/find-active-queue-info.dto.ts
+++ b/src/domain/queue/domain/dto/info/find-active-queue-info.dto.ts
@@ -1,0 +1,39 @@
+import { QueueEntity, QueueStatus } from '../../model';
+
+export class FindActiveQueueInfo
+  implements
+    Pick<
+      QueueEntity,
+      | 'uid'
+      | 'userId'
+      | 'concertId'
+      | 'status'
+      | 'activeExpireAt'
+      | 'activeFirstAccessAt'
+    >
+{
+  constructor(
+    readonly uid: string,
+    readonly userId: number,
+    readonly concertId: number,
+    readonly status: QueueStatus,
+    readonly activeExpireAt?: Date,
+    readonly activeFirstAccessAt?: Date,
+  ) {}
+
+  static of(domain: QueueEntity[]): FindActiveQueueInfo[];
+  static of(domain: QueueEntity): FindActiveQueueInfo;
+  static of(
+    domain: QueueEntity | QueueEntity[],
+  ): FindActiveQueueInfo | FindActiveQueueInfo[] {
+    if (Array.isArray(domain)) return domain.map((d) => this.of(d));
+    return new FindActiveQueueInfo(
+      domain.uid,
+      domain.userId,
+      domain.concertId,
+      domain.status,
+      domain.activeExpireAt,
+      domain.activeFirstAccessAt,
+    );
+  }
+}

--- a/src/domain/queue/domain/dto/info/index.ts
+++ b/src/domain/queue/domain/dto/info/index.ts
@@ -1,2 +1,3 @@
 export * from './create-queue-info.dto';
 export * from './get-queue-info.dto';
+export * from './find-active-queue-info.dto';

--- a/src/domain/queue/domain/model/enum/queue-status.enum.ts
+++ b/src/domain/queue/domain/model/enum/queue-status.enum.ts
@@ -1,7 +1,5 @@
 /** 콘서트 좌석 상태 */
 export enum QueueStatus {
-  /** 없음 */
-  NONE = 'None',
   /** 대기 */
   WAIT = 'Wait',
   /** 활성 */

--- a/src/domain/queue/domain/model/queue.entity.ts
+++ b/src/domain/queue/domain/model/queue.entity.ts
@@ -6,6 +6,9 @@ import { QueueStatus } from '../../domain';
 
 @Entity('queue')
 export class QueueEntity extends BaseEntity {
+  /** 활성화 최대 시간(분) */
+  static MAX_ACTIVE_MINUTE: number = 10;
+
   @Column()
   uid: string;
 
@@ -18,14 +21,43 @@ export class QueueEntity extends BaseEntity {
   @Column()
   status: QueueStatus;
 
-  @Column('datetime', { nullable: true })
+  @Column('datetime', { nullable: true, comment: '만료시간' })
   activeExpireAt?: Date;
 
-  @Column('datetime', { nullable: true })
-  activeAt?: Date;
+  @Column('datetime', { nullable: true, comment: '활성화된 시간' })
+  activedAt?: Date;
+
+  @Column('datetime', { nullable: true, comment: '활성화 후 첫 요청 시간' })
+  activeFirstAccessAt?: Date;
 
   /* ================================ Domain Method ================================ */
   static generateUUIDv4() {
     return crypto.randomUUID();
+  }
+
+  get isFirstAccessAfterActive(): boolean {
+    return (
+      this.status === QueueStatus.ACTIVE && this.activeFirstAccessAt === null
+    );
+  }
+
+  /**
+   * 큐 활성화 만료시간을 계산하고 셋팅한다.
+   * @param currentDate - 현재 시간
+   * @returns
+   */
+  calculateActiveExpire(currentDate: Date = new Date()): this {
+    if (this.activeExpireAt) return this;
+
+    const addMinutes = (date: Date, minutes: number) => {
+      return new Date(date.getTime() + minutes * 60_000);
+    };
+
+    this.activeFirstAccessAt = currentDate;
+    this.activeExpireAt = addMinutes(
+      this.activeFirstAccessAt,
+      QueueEntity.MAX_ACTIVE_MINUTE,
+    );
+    return this;
   }
 }

--- a/src/domain/queue/infra/queue.repository.ts
+++ b/src/domain/queue/infra/queue.repository.ts
@@ -4,17 +4,21 @@ import { BaseRepository } from 'src/common';
 import { QueueEntity } from '../domain';
 import { FindManyOptions } from 'typeorm';
 
-export type InsertQueueParam = Pick<
-  QueueEntity,
-  'concertId' | 'uid' | 'status' | 'userId'
->;
-
 export type FindOptions = Pick<FindManyOptions, 'order' | 'take'> & {
   where: FindOptionsWhere;
 };
 export type FindOptionsWhere = Pick<
   Partial<QueueEntity>,
   'uid' | 'concertId' | 'status'
+>;
+
+export type InsertQueueParam = Pick<
+  QueueEntity,
+  'concertId' | 'uid' | 'status' | 'userId'
+>;
+export type UpdateQueueParam = Pick<
+  Partial<QueueEntity>,
+  'status' | 'activeExpireAt' | 'activedAt' | 'activeFirstAccessAt'
 >;
 
 @Injectable()
@@ -26,10 +30,16 @@ export abstract class QueueRepository extends BaseRepository<QueueEntity> {
   abstract getWaitingNumber(queueEntity: QueueEntity): Promise<number>;
 
   abstract saveQueue(param: InsertQueueParam): Promise<QueueEntity>;
-  abstract updateQueue(queueEntity: QueueEntity): Promise<void>;
+  abstract updateQueue(
+    queueUid: string,
+    param: UpdateQueueParam,
+  ): Promise<void>;
 
-  abstract updateQueues(queueEntities: QueueEntity[]): Promise<void>;
+  abstract updateQueues(
+    queueUids: string[],
+    param: UpdateQueueParam,
+  ): Promise<void>;
 
   /** 현재시간 기준 만료시간(activeExpireAt)이 지난 토큰 모두 상태를 "만료"처리 */
-  abstract updateExpireQueues(date?: Date): Promise<void>;
+  abstract updateAllExpireQueues(date?: Date): Promise<void>;
 }

--- a/src/domain/queue/infra/queue.repository.ts
+++ b/src/domain/queue/infra/queue.repository.ts
@@ -10,15 +10,26 @@ export type InsertQueueParam = Pick<
 >;
 
 export type FindOptions = Pick<FindManyOptions, 'order' | 'take'> & {
-  where: Pick<Partial<QueueEntity>, 'concertId' | 'status'>;
+  where: FindOptionsWhere;
 };
+export type FindOptionsWhere = Pick<
+  Partial<QueueEntity>,
+  'uid' | 'concertId' | 'status'
+>;
 
 @Injectable()
 export abstract class QueueRepository extends BaseRepository<QueueEntity> {
-  abstract getQueuesBy(options: FindOptions): Promise<QueueEntity[]>;
+  abstract getQueues(options: FindOptions): Promise<QueueEntity[]>;
+
   abstract getQueueByUid(queueUid: string): Promise<QueueEntity>;
+  abstract findQueueBy(options: FindOptionsWhere): Promise<QueueEntity>;
   abstract getWaitingNumber(queueEntity: QueueEntity): Promise<number>;
 
   abstract saveQueue(param: InsertQueueParam): Promise<QueueEntity>;
+  abstract updateQueue(queueEntity: QueueEntity): Promise<void>;
+
   abstract updateQueues(queueEntities: QueueEntity[]): Promise<void>;
+
+  /** 현재시간 기준 만료시간(activeExpireAt)이 지난 토큰 모두 상태를 "만료"처리 */
+  abstract updateExpireQueues(date?: Date): Promise<void>;
 }

--- a/src/domain/queue/presentation/queue.schedule.ts
+++ b/src/domain/queue/presentation/queue.schedule.ts
@@ -52,7 +52,7 @@ export class QueueSchedule implements OnApplicationBootstrap {
     job.start();
   }
 
-  @Cron(QueueSchedule.CON_TIME, {
+  @Cron(CronExpression.EVERY_10_SECONDS, {
     name: QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS,
   })
   async changeQueueExpireStatus() {

--- a/src/domain/queue/presentation/queue.schedule.ts
+++ b/src/domain/queue/presentation/queue.schedule.ts
@@ -52,10 +52,9 @@ export class QueueSchedule implements OnApplicationBootstrap {
     job.start();
   }
 
-  // @Cron(QueueSchedule.CON_TIME, {
-  //   name: QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS,
-  // })
-  // TODO: 서비스 제한시간이 자닌 토큰 만료 처리
+  @Cron(QueueSchedule.CON_TIME, {
+    name: QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS,
+  })
   async changeQueueExpireStatus() {
     this.logger.warn(`[${QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS}] start`);
 

--- a/src/domain/queue/queue.module.ts
+++ b/src/domain/queue/queue.module.ts
@@ -15,5 +15,6 @@ import { AuthModule } from '../auth';
     QueueService,
     { provide: QueueRepository, useClass: QueueCoreRepository },
   ],
+  exports: [QueueService],
 })
 export class QueueModule {}

--- a/test/fixture/mock-entity-generator.ts
+++ b/test/fixture/mock-entity-generator.ts
@@ -73,8 +73,9 @@ export class MockEntityGenerator {
     queue.status = QueueStatus.WAIT;
     queue.userId = param.userId ?? 1;
     queue.concertId = param.concertId ?? 1;
-    queue.activeAt = null;
+    queue.activedAt = null;
     queue.activeExpireAt = null;
+    queue.activeFirstAccessAt = null;
     return queue;
   }
 


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [x] 기능 추가(테스트 추가)
- [x] 기능 개선(테스트 개선)
- [ ] 기능 삭제(테스트 삭제)
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> [!NOTE] 
> 구체적인 작업 내용을 정리하면 좋습니다.

1. 대기큐 사용 시간 최대 만료 처리를 위한 로직 추가

## 2️⃣ 의사결정 흐름
> [!NOTE] 
> 구현된 코드의 근거나 배경에 대해 설명하면 좋습니다.

### 대기큐 사용 시간 최대 만료 처리를 위한 로직 추가

#### 2.1. 먼저 `JwtGuard` 가드에서 queue의 상태를 조회합니다.

a. jwt를 복호화 하고 `queueUid`를 찾습니다. 
b. 그리고 `queueUid`를 사용해서 현재 queue의 상태를 찾습니다.
  - `await this.queueService.findActiveQueue(payload.queueUid);`를 통해서 조회
c. queueInfo를 조회할 때 `QueueEntity#activeFirstAccessAt`이 없다면 값을 현재시간으로 채워줍니다.
d. 활성 상태가 아니거나, 활성 시간이 지났다면 401에러를 응답합니다.

```typescript
export class JwtGuard extends BaseJwtGuard {
  constructor(
    private readonly authService: AuthService,
    private readonly queueService: QueueService,
  ) {
    super();
  }

  async canActivate(context: ExecutionContext): Promise<boolean> {
    const request = this.getRequest<UserRequest>(context);
    const jwt = this.getJwt(request);
    const payload = this.authService.decodeToken(jwt);
    if (!payload) throw new UnauthorizedException();

    // 큐 만료 체크
    const queueInfo = await this.queueService.findActiveQueue(payload.queueUid);
    if (!queueInfo) throw new UnauthorizedException();
    if (queueInfo.activeFirstAccessAt < new Date())
      throw new UnauthorizedException();

    const userInfo: UserInfo = {
      userId: payload.userId,
      queueUid: payload.queueUid,
      jwt,
    };
    request.user = userInfo;
    return true;
  }
}
```

#### 2.2. `QueueSchedule#changeQueueExpireStatus`에서 스케줄링을 통해 만료 처리합니다.

```typescript
  @Cron(CronExpression.EVERY_10_SECONDS, {
    name: QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS,
  })
  async changeQueueExpireStatus() {
    this.logger.warn(`[${QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS}] start`);

    const job = this.schedulerRegistry.getCronJob(
      QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS,
    );
    job.stop();

    try {
      await this.queueFacade.changeQueueExpireStatus();
    } catch (error) {
      this.logger.error(error as Error);
    }
    this.logger.warn(`[${QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS}] end`);
    job.start();
  }
```

## 3️⃣ 리뷰 포인트
> [!NOTE] 
> 명확한 리뷰 포인트나, 리뷰 받고 싶은 코드를 참조하면 좋습니다.

-  

## 4️⃣ 이슈
> [!NOTE] (optional) 공유하고 싶은 이슈나, 코드가 가진 문제(한계)를 알려주세요.

- 가드에서 최초요청 시간을 넣는 코드를 호출하는게 맞는지 계속 고민하고 있습니다.

 