### PR TITLE
Feat/redis로 대기열 로직 개선

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { CacheModule } from '@nestjs/cache-manager';
+import Redis from 'ioredis';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -12,9 +14,10 @@ import {
   RedisCacheStore,
 } from './common';
 import { DomainModule } from './domain';
-import { AopModule, CustomLoggerModule } from './global';
-import { CacheModule } from '@nestjs/cache-manager';
-import Redis from 'ioredis';
+import { AopModule, CustomLoggerModule, RedisModule } from './global';
+
+const cacheRedis = new Redis({ db: 0 });
+const clientRedis = new Redis({ db: 1 });
 
 @Module({
   imports: [
@@ -22,13 +25,15 @@ import Redis from 'ioredis';
       ...getTypeOrmModuleAsyncOptions(),
     }),
     CacheModule.register({
-      store: new RedisCacheStore(new Redis()),
+      store: new RedisCacheStore(cacheRedis),
       isGlobal: true,
     }),
     ScheduleModule.forRoot(),
 
+    /* custom module */
     CustomLoggerModule.forRoot(),
     AopModule.forRoot(),
+    RedisModule.forRoot(clientRedis),
     DomainModule,
   ],
   controllers: [AppController],

--- a/src/common/class/cache-store.ts
+++ b/src/common/class/cache-store.ts
@@ -1,7 +1,8 @@
 import { CacheStore } from '@nestjs/cache-manager';
+import { OnModuleDestroy } from '@nestjs/common';
 import { Redis } from 'ioredis';
 
-export type RedisType = Pick<Redis, 'get' | 'set' | 'setex' | 'del'>;
+export type RedisType = Pick<Redis, 'get' | 'set' | 'setex' | 'del' | 'quit'>;
 
 export abstract class BaseCacheStore implements CacheStore {
   abstract get<T>(key: string): Promise<T | undefined> | T | undefined;
@@ -9,12 +10,16 @@ export abstract class BaseCacheStore implements CacheStore {
   abstract del?(key: string): void | Promise<void>;
 }
 
-export class RedisCacheStore extends BaseCacheStore {
+export class RedisCacheStore extends BaseCacheStore implements OnModuleDestroy {
   constructor(private readonly redisClient: RedisType) {
     super();
   }
 
-  async get<T>(key: string): Promise<T | null> {
+  async onModuleDestroy() {
+    await this.redisClient.quit();
+  }
+
+  override async get<T>(key: string): Promise<T | null> {
     const value = await this.redisClient.get(key);
     return value ? JSON.parse(value) : null;
   }
@@ -25,7 +30,7 @@ export class RedisCacheStore extends BaseCacheStore {
    * @param value
    * @param ttl - `redisClient` ioredis를 사용하는 경우 초(seconds)단위만 사용가능하다.
    */
-  async set<T>(key: string, value: T, ttl?: number): Promise<void> {
+  override async set<T>(key: string, value: T, ttl?: number): Promise<void> {
     const stringValue = JSON.stringify(value);
 
     if (ttl) {
@@ -35,7 +40,7 @@ export class RedisCacheStore extends BaseCacheStore {
     }
   }
 
-  async del(key: string): Promise<void> {
+  override async del(key: string): Promise<void> {
     await this.redisClient.del(key);
   }
 }

--- a/src/domain/concert/performance/application/performance.facade.ts
+++ b/src/domain/concert/performance/application/performance.facade.ts
@@ -35,12 +35,9 @@ export class PerformanceFacade {
   async reserveSeat(command: WriteReservationCommand) {
     await this.userService.getUser(command.userId);
 
-    return await this.manager.transaction(async (txManager) => {
-      const reservationId =
-        this.performanceService.reserveSeat(command)(txManager);
-
-      await this.queueService.expireQueue(command.queueUid)(txManager);
-      return reservationId;
-    });
+    const reservationId = await this.performanceService.reserveSeat(command)();
+    // Note: 활성 토큰 만료에 실패한다고 롤백 시키지 않는다.
+    await this.queueService.expireActiveQueue(command.queueUid);
+    return reservationId;
   }
 }

--- a/src/domain/queue/application/queue.facade.ts
+++ b/src/domain/queue/application/queue.facade.ts
@@ -37,8 +37,4 @@ export class QueueFacade {
   async changeQueueActiveStatus(activeCount: number): Promise<void> {
     await this.queueService.batchQueueActiveStatus(activeCount);
   }
-
-  async changeQueueExpireStatus(): Promise<void> {
-    await this.queueService.changeAllExpireStatus();
-  }
 }

--- a/src/domain/queue/domain/dto/info/create-queue-info.dto.ts
+++ b/src/domain/queue/domain/dto/info/create-queue-info.dto.ts
@@ -1,4 +1,4 @@
-import { QueueEntity, QueueStatus } from '../../model';
+import { QueueDomain, QueueEntity, QueueStatus } from '../../model';
 
 export class CreateQueueInfo implements Pick<QueueEntity, 'uid' | 'status'> {
   constructor(
@@ -7,12 +7,16 @@ export class CreateQueueInfo implements Pick<QueueEntity, 'uid' | 'status'> {
     readonly dateTime: Date,
   ) {}
 
-  static of(domain: QueueEntity[]): CreateQueueInfo[];
-  static of(domain: QueueEntity): CreateQueueInfo;
+  static of(domain: QueueDomain[]): CreateQueueInfo[];
+  static of(domain: QueueDomain): CreateQueueInfo;
   static of(
-    domain: QueueEntity | QueueEntity[],
+    domain: QueueDomain | QueueDomain[],
   ): CreateQueueInfo | CreateQueueInfo[] {
     if (Array.isArray(domain)) return domain.map((d) => this.of(d));
-    return new CreateQueueInfo(domain.uid, domain.status, domain.createdAt);
+    return new CreateQueueInfo(
+      domain.uid,
+      domain.status,
+      new Date(domain.timestamp),
+    );
   }
 }

--- a/src/domain/queue/domain/dto/info/find-active-queue-info.dto.ts
+++ b/src/domain/queue/domain/dto/info/find-active-queue-info.dto.ts
@@ -1,4 +1,4 @@
-import { QueueEntity, QueueStatus } from '../../model';
+import { QueueDomain, QueueEntity, QueueStatus } from '../../model';
 
 export class FindActiveQueueInfo
   implements
@@ -21,10 +21,10 @@ export class FindActiveQueueInfo
     readonly activeFirstAccessAt?: Date,
   ) {}
 
-  static of(domain: QueueEntity[]): FindActiveQueueInfo[];
-  static of(domain: QueueEntity): FindActiveQueueInfo;
+  static of(domain: QueueDomain[]): FindActiveQueueInfo[];
+  static of(domain: QueueDomain): FindActiveQueueInfo;
   static of(
-    domain: QueueEntity | QueueEntity[],
+    domain: QueueDomain | QueueDomain[],
   ): FindActiveQueueInfo | FindActiveQueueInfo[] {
     if (Array.isArray(domain)) return domain.map((d) => this.of(d));
     return new FindActiveQueueInfo(
@@ -32,7 +32,6 @@ export class FindActiveQueueInfo
       domain.userId,
       domain.concertId,
       domain.status,
-      domain.activeExpireAt,
       domain.activeFirstAccessAt,
     );
   }

--- a/src/domain/queue/domain/dto/info/get-queue-info.dto.ts
+++ b/src/domain/queue/domain/dto/info/get-queue-info.dto.ts
@@ -1,9 +1,7 @@
-import { QueueEntity, QueueStatus } from '../../model';
+import { QueueDomain, QueueEntity, QueueStatus } from '../../model';
 
-type GetQueueInfoParam = Pick<
-  QueueEntity,
-  'uid' | 'userId' | 'concertId' | 'status'
-> & {
+type GetQueueInfoParam = {
+  queue: Pick<QueueDomain, 'uid' | 'userId' | 'concertId' | 'status'>;
   waitingNumber: number;
 };
 
@@ -23,10 +21,10 @@ export class GetQueueInfo implements Pick<QueueEntity, 'status'> {
   ): GetQueueInfo | GetQueueInfo[] {
     if (Array.isArray(param)) return param.map((d) => this.of(d));
     return new GetQueueInfo(
-      param.uid,
-      param.userId,
-      param.concertId,
-      param.status,
+      param.queue.uid,
+      param.queue.userId,
+      param.queue.concertId,
+      param.queue.status,
       param.waitingNumber,
     );
   }

--- a/src/domain/queue/domain/model/index.ts
+++ b/src/domain/queue/domain/model/index.ts
@@ -1,2 +1,3 @@
 export * from './queue.entity';
+export * from './queue.domain';
 export * from './enum';

--- a/src/domain/queue/domain/model/queue.domain.ts
+++ b/src/domain/queue/domain/model/queue.domain.ts
@@ -1,0 +1,112 @@
+import * as crypto from 'crypto';
+
+import { ConflictStatusException } from 'src/common';
+import { QueueStatus } from './enum';
+
+type QueueDomainProp = {
+  uid: string;
+  userId: number;
+  concertId: number;
+  status: QueueStatus;
+  timestamp: number;
+  activedAt?: Date;
+  activeFirstAccessAt?: Date;
+};
+
+export class QueueDomain {
+  constructor(private readonly prop: QueueDomainProp) {}
+
+  /** 활성화 최대 시간(분) - 5분 */
+  static MAX_ACTIVE_MINUTE: number = 5 * 60;
+
+  get uid(): string {
+    return this.prop.status;
+  }
+
+  get userId(): number {
+    return this.prop.userId;
+  }
+
+  get concertId(): number {
+    return this.prop.concertId;
+  }
+
+  get status(): QueueStatus {
+    return this.prop.status;
+  }
+
+  get timestamp(): number {
+    return this.prop.timestamp;
+  }
+
+  // get activeExpireAt(): Date {
+  //   return this.prop.activeExpireAt;
+  // }
+
+  get activedAt(): Date | null {
+    return this.prop.activedAt;
+  }
+
+  get activeFirstAccessAt(): Date | null {
+    return this.prop.activeFirstAccessAt;
+  }
+
+  /* ================================ Domain Method ================================ */
+  static generateUUIDv4() {
+    return crypto.randomUUID();
+  }
+
+  static from(prop: QueueDomainProp): QueueDomain;
+  static from(prop: QueueDomainProp[]): QueueDomain[];
+  static from(prop: QueueDomainProp | QueueDomainProp[]) {
+    if (Array.isArray(prop)) return prop.map((p) => this.from(p));
+    return new QueueDomain(prop);
+  }
+
+  /**
+   * 활성화 가능 여부
+   * @returns {boolean}
+   */
+  get isActive(): boolean {
+    return this.status === QueueStatus.WAIT;
+  }
+
+  /**
+   * 만료 가능 여부
+   * @returns {boolean}
+   */
+  get isExpire(): boolean {
+    return this.status === QueueStatus.WAIT;
+  }
+
+  get isFirstAccessAfterActive(): boolean {
+    return (
+      this.status === QueueStatus.ACTIVE && this.activeFirstAccessAt === null
+    );
+  }
+
+  active(activedAt: Date = new Date()): this {
+    if (!this.isActive) {
+      throw new ConflictStatusException('활성화 가능 상태가 아닙니다.');
+    }
+    this.prop.status = QueueStatus.ACTIVE;
+    this.prop.activedAt = activedAt;
+    return this;
+  }
+
+  firstAccess(activeFirstAccessAt: Date = new Date()): this {
+    if (!this.isActive) {
+      throw new ConflictStatusException('활성화 상태가 아닙니다.');
+    }
+    this.prop.activeFirstAccessAt = activeFirstAccessAt;
+    return this;
+  }
+
+  expire(): this {
+    if (!this.isActive) {
+      throw new ConflictStatusException('만료 가능 상태가 아닙니다.');
+    }
+    this.prop.status = QueueStatus.EXPIRE;
+    return this;
+  }
+}

--- a/src/domain/queue/infra/index.ts
+++ b/src/domain/queue/infra/index.ts
@@ -1,2 +1,4 @@
 export * from './queue-core.repository';
 export * from './queue.repository';
+export * from './queue-redis.client';
+export * from './queue-redis-core.client';

--- a/src/domain/queue/infra/queue-redis-core.client.ts
+++ b/src/domain/queue/infra/queue-redis-core.client.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@nestjs/common';
+import { ResourceNotFoundException } from 'src/common';
+import { RedisClient } from 'src/global';
+import { QueueDomain } from '../domain';
+import {
+  FindRange,
+  QueueRedisClient,
+  SetWaitQueueParam,
+} from './queue-redis.client';
+
+// TODO: ActiveQueue와 WaitQueue로 나누고 전반적인 리펙터링 예정
+@Injectable()
+export class QueueCoreRedisClient extends QueueRedisClient {
+  /** 대기열 key */
+  private readonly WAITING_QUEUE_KEY = 'waiting:queue';
+  /** 사용열 key */
+  private readonly ACTIVE_USERS_KEY = 'active:users';
+
+  constructor(private readonly redisClient: RedisClient) {
+    super();
+  }
+
+  override async setWaitQueue(param: SetWaitQueueParam): Promise<void> {
+    const multi = this.redisClient.multi();
+    // 대기열 정보
+    multi.hmset(param.uid, param);
+
+    // 대기열 순서
+    multi.zadd(
+      this.WAITING_QUEUE_KEY,
+      param.timestamp,
+      JSON.stringify({ ...param }),
+    );
+    await multi.exec();
+  }
+
+  override async getWaitQueue(queueUid: string): Promise<QueueDomain> {
+    const record = await this.redisClient.hgetall(queueUid);
+    if (!record) throw new ResourceNotFoundException();
+    return QueueDomain.from(record as any);
+  }
+
+  override async getWaitingNumber(queue: QueueDomain): Promise<number> {
+    const rank = await this.redisClient.zrank(
+      this.WAITING_QUEUE_KEY,
+      JSON.stringify(queue), // member는 저장했던 데이터와 정확히 일치해야 한다.
+    );
+    return rank;
+  }
+
+  override async findActiveQueue(queueUid: string): Promise<QueueDomain> {
+    const record = await this.redisClient.get(queueUid);
+    return QueueDomain.from(JSON.parse(record));
+  }
+
+  override async setExActiveQueue(
+    queueUid: string,
+    queue: QueueDomain,
+  ): Promise<void> {
+    // 만료시간 설정
+    this.redisClient.setEX(queueUid, JSON.stringify(queue), {
+      ttlSeconds: QueueDomain.MAX_ACTIVE_MINUTE,
+    });
+  }
+
+  override async setActiveQueues(range: FindRange): Promise<void> {
+    // 1. 대기열에서 조회
+    const members = await this.redisClient.zrange(
+      this.WAITING_QUEUE_KEY,
+      range.start,
+      range.stop - 1,
+    );
+    if (members.length === 0) return;
+
+    // redis 트랜잭션
+    const multi = this.redisClient.multi();
+    members.forEach((member) => {
+      // 2. 활성 사용자로 등록
+      const queue = QueueDomain.from(JSON.parse(member)).active();
+      multi.set(
+        `${this.ACTIVE_USERS_KEY}:${queue.uid}`, // active:users:${queueUid}
+        JSON.stringify(queue),
+      );
+      // 3. 대기열에서 제거
+      multi.zrem(this.WAITING_QUEUE_KEY, member);
+    });
+
+    // 한번에 전송
+    await multi.exec();
+  }
+
+  override async deleteActiveQueue(queueUids: string): Promise<void> {
+    await this.redisClient.del(`${this.ACTIVE_USERS_KEY}:${queueUids}`);
+  }
+}

--- a/src/domain/queue/infra/queue-redis.client.ts
+++ b/src/domain/queue/infra/queue-redis.client.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import { QueueDomain } from '../domain';
+
+export type SetWaitQueueParam = Pick<
+  QueueDomain,
+  'uid' | 'concertId' | 'status' | 'userId' | 'timestamp'
+>;
+export type FindRange = { start: number; stop: number };
+
+@Injectable()
+export abstract class QueueRedisClient {
+  /**
+   * 대기열에 등록
+   * - ZADD 를 사용해 Sorted Set으로 저장한다.
+   * @param param
+   */
+  abstract setWaitQueue(param: SetWaitQueueParam): Promise<void>;
+
+  /**
+   * 대기열의 토큰 조회
+   * @param queueUid
+   */
+  abstract getWaitQueue(queueUid: string): Promise<QueueDomain>;
+
+  /**
+   * 대기열에서 내 앞의 대기 인원 계산
+   * @returns 앞 대기 인원 수 (본인 제외), 대기열에 없으면 -1 반환
+   */
+  abstract getWaitingNumber(queue: QueueDomain): Promise<number>;
+
+  abstract findActiveQueue(queueUid: string): Promise<QueueDomain>;
+  abstract setExActiveQueue(
+    queueUid: string,
+    queue: QueueDomain,
+  ): Promise<void>;
+  /**
+   * 범위에 지정된 만큼 사용열로 이동
+   * - 대기열(ZADD)에서 제거
+   * - 사용열(SETEX)에 추가 하고, TTL을 지정한다.
+   * @param param
+   */
+  abstract setActiveQueues(param: FindRange): Promise<void>;
+
+  /**
+   * 사용열에 있는 토큰을 제거한다.
+   * @param queueUids
+   */
+  abstract deleteActiveQueue(queueUids: string): Promise<void>;
+}

--- a/src/domain/queue/presentation/queue.schedule.ts
+++ b/src/domain/queue/presentation/queue.schedule.ts
@@ -51,25 +51,4 @@ export class QueueSchedule implements OnApplicationBootstrap {
 
     job.start();
   }
-
-  @Cron(CronExpression.EVERY_10_SECONDS, {
-    name: QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS,
-  })
-  async changeQueueExpireStatus() {
-    this.logger.warn(`[${QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS}] start`);
-
-    const job = this.schedulerRegistry.getCronJob(
-      QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS,
-    );
-    job.stop();
-
-    try {
-      await this.queueFacade.changeQueueExpireStatus();
-    } catch (error) {
-      this.logger.error(error as Error);
-    }
-    this.logger.warn(`[${QueueSchedule.JOB.CHANGE_QUEUE_EXPIRE_STATUS}] end`);
-
-    job.start();
-  }
 }

--- a/src/domain/queue/queue.module.ts
+++ b/src/domain/queue/queue.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth';
 import { QueueFacade } from './application';
 import { QueueService } from './domain/queue.service';
-import { QueueCoreRepository, QueueRepository } from './infra';
+import { QueueCoreRedisClient, QueueRedisClient } from './infra';
 import { QueueController, QueueSchedule } from './presentation';
 
 @Module({
@@ -13,7 +13,7 @@ import { QueueController, QueueSchedule } from './presentation';
     QueueSchedule,
     QueueFacade,
     QueueService,
-    { provide: QueueRepository, useClass: QueueCoreRepository },
+    { provide: QueueRedisClient, useClass: QueueCoreRedisClient },
   ],
   exports: [QueueService],
 })

--- a/src/global/index.ts
+++ b/src/global/index.ts
@@ -1,2 +1,3 @@
 export * from './logger';
 export * from './aop';
+export * from './redis';

--- a/src/global/redis/index.ts
+++ b/src/global/redis/index.ts
@@ -1,0 +1,2 @@
+export * from './redis.client';
+export * from './redis.module';

--- a/src/global/redis/redis.client.ts
+++ b/src/global/redis/redis.client.ts
@@ -1,0 +1,239 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import Redis, { ChainableCommander } from 'ioredis';
+
+@Injectable()
+export class RedisClient implements OnModuleDestroy {
+  constructor(private readonly redis: Redis) {}
+
+  async onModuleDestroy() {
+    await this.redis.quit();
+  }
+
+  /**
+   * 키-값을 조회합니다.
+   * @param key 키
+   * @returns 저장된 값
+   */
+  async get(key: string): Promise<string | null> {
+    return await this.redis.get(key);
+  }
+
+  /**
+   * 키-값을 설정
+   * @param key 키
+   * @param value 값
+   * @param ttlSeconds 만료 시간(초)
+   * @returns 성공 여부
+   */
+  async set(key: string, value: string | number): Promise<boolean> {
+    const result = await this.redis.set(key, value);
+    return result === 'OK';
+  }
+
+  /**
+   * 키가 존재하는지 확인합니다.
+   * @param key 키
+   * @returns 존재 여부
+   */
+  async exists(key: string): Promise<boolean> {
+    return (await this.redis.exists(key)) === 1;
+  }
+
+  /**
+   * 키를 삭제합니다.
+   * @param key 키
+   * @returns 삭제된 키의 수
+   */
+  async del(key: string): Promise<number> {
+    return await this.redis.del(key);
+  }
+
+  /**
+   * 키의 만료 시간을 설정합니다.
+   * @param key 키
+   * @param seconds 만료 시간(초)
+   * @returns 성공 여부
+   */
+  async expire(key: string, seconds: number): Promise<boolean> {
+    return (await this.redis.expire(key, seconds)) === 1;
+  }
+
+  /**
+   * 키-값을 설정하고 만료시간을 지정합니다.
+   * @param key 키
+   * @param value 값
+   * @param ttlSeconds 만료 시간(초)
+   * @returns 성공 여부
+   */
+  async setEX(
+    key: string,
+    value: string | number,
+    { ttlSeconds }: { ttlSeconds?: number } = {},
+  ): Promise<boolean> {
+    const result = await this.redis.setex(key, ttlSeconds, value);
+    // await redis.set(key, value, 'EX', ttlSeconds, 'NX');
+    return result === 'OK';
+  }
+
+  /**
+   * 키가 존재하지 않을 때만 값을 설정합니다.
+   * @param key 키 (key)
+   * @param value 값 (value)
+   * @param ttlSeconds 만료 시간(초)
+   * @returns 성공 여부
+   */
+  async setNX(
+    key: string,
+    value: string | number,
+    { ttlSeconds }: { ttlSeconds?: number } = {},
+  ): Promise<boolean> {
+    if (ttlSeconds) {
+      // SET key value EX seconds NX
+      const result = await this.redis.set(key, value, 'EX', ttlSeconds, 'NX');
+      return result === 'OK';
+    }
+
+    // SET key value NX
+    const result = await this.redis.set(key, value, 'NX');
+    return result === 'OK';
+  }
+
+  /* ---------------------- Set ---------------------- */
+  /**
+   * Sorted Set에 score와 함께 값을 추가합니다.
+   * @param key Sorted Set 키 (key)
+   * @param score 점수로 사용될 값
+   * @param member 저장할 객체 (value)
+   * @returns 추가된 항목 수
+   */
+  async zadd(key: string, score: number, member: string): Promise<number> {
+    return await this.redis.zadd(key, score, member);
+  }
+
+  /**
+   * Sorted Set에서 범위로 값을 조회합니다.
+   * @param key Sorted Set 키
+   * @param start 시작 인덱스
+   * @param stop 종료 인덱스
+   * @returns 조회된 값들
+   */
+  async zrange(key: string, start: number, stop: number): Promise<string[]> {
+    return await this.redis.zrange(key, start, stop);
+  }
+
+  /**
+   * zrank 순위를 조회 합니다.
+   * @param key
+   * @returns
+   */
+  async zrank(key: string, token: string): Promise<number> {
+    const rank = await this.redis.zrank(key, token);
+    return rank === null ? -1 : rank + 1;
+  }
+
+  /**
+   * zscore 점수를 조회 합니다.
+   * @param key
+   * @returns
+   */
+  async zscore(key: string, member: string): Promise<string> {
+    return await this.redis.zscore(key, member);
+  }
+
+  /**
+   * Set에 여러 값을 추가합니다.
+   * @param key Set 키
+   * @param members 추가할 값들
+   * @returns 추가된 항목 수
+   */
+  async sadd(key: string, ...members: string[]): Promise<number> {
+    return await this.redis.sadd(key, ...members);
+  }
+
+  /**
+   * Set의 모든 멤버를 조회합니다.
+   * @param key Set 키
+   * @returns Set의 모든 멤버
+   */
+  async smembers(key: string): Promise<string[]> {
+    return await this.redis.smembers(key);
+  }
+
+  /* ---------------------- Hash ---------------------- */
+
+  /**
+   * Hash에 단일 필드를 설정합니다.
+   * @param key Hash 키
+   * @param field 필드 이름
+   * @param value 값
+   * @returns 성공 여부 (새로운 필드면 1, 기존 필드 갱신이면 0)
+   */
+  async hset(
+    key: string,
+    field: string,
+    value: string | number,
+  ): Promise<number> {
+    return await this.redis.hset(key, field, value);
+  }
+
+  /**
+   * Hash에 여러 필드를 한번에 설정합니다.
+   * @param key Hash 키
+   * @param data 필드-값 쌍의 객체
+   * @returns 성공 여부
+   */
+  async hmset(
+    key: string,
+    data: Record<string, string | number>,
+  ): Promise<boolean> {
+    const result = await this.redis.hmset(key, data);
+    return result === 'OK';
+  }
+
+  /**
+   * Hash에서 특정 필드의 값을 조회합니다.
+   * @param key Hash 키
+   * @param field 필드 이름
+   * @returns 필드 값
+   */
+  async hget(key: string, field: string): Promise<string | null> {
+    return await this.redis.hget(key, field);
+  }
+
+  /**
+   * Hash의 모든 필드-값을 조회합니다.
+   * @param key Hash 키
+   * @returns 모든 필드-값 쌍
+   */
+  async hgetall(key: string): Promise<Record<string, string>> {
+    return await this.redis.hgetall(key);
+  }
+
+  /**
+   * Hash에서 특정 필드가 존재하는지 확인합니다.
+   * @param key Hash 키
+   * @param field 필드 이름
+   * @returns 존재 여부
+   */
+  async hexists(key: string, field: string): Promise<boolean> {
+    return (await this.redis.hexists(key, field)) === 1;
+  }
+
+  /**
+   * Hash에서 특정 필드를 삭제합니다.
+   * @param key Hash 키
+   * @param field 필드 이름
+   * @returns 삭제된 필드 수
+   */
+  async hdel(key: string, field: string): Promise<number> {
+    return await this.redis.hdel(key, field);
+  }
+
+  /**
+   * 트랜잭션을 시작합니다.
+   * @returns Redis Pipeline
+   */
+  multi(): ChainableCommander {
+    return this.redis.multi();
+  }
+}

--- a/src/global/redis/redis.module.ts
+++ b/src/global/redis/redis.module.ts
@@ -1,0 +1,24 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { RedisClient } from './redis.client';
+import Redis from 'ioredis';
+
+@Module({})
+export class RedisModule {
+  static forRoot(redis?: Redis): DynamicModule {
+    const redisClient = redis
+      ? new RedisClient(redis)
+      : new RedisClient(new Redis());
+
+    return {
+      global: true,
+      module: RedisModule,
+      providers: [
+        {
+          provide: RedisClient,
+          useValue: redisClient,
+        },
+      ],
+      exports: [RedisClient],
+    };
+  }
+}


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [ ] 기능 추가(테스트 추가)
- [x] 기능 개선(테스트 개선)
- [x] 기능 삭제(테스트 삭제)
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> [!NOTE] 구체적인 작업 내용을 정리하면 좋습니다.

1. 대기열 로직 RDS를 사용하던 로직 모두 Redis를 사용하도록 코드 수정
2. Redis 사용으로 인한 대기큐 만료 처리 로직 제거

## 2️⃣ 의사결정 흐름
> [!NOTE] 구현된 코드의 근거나 배경에 대해 설명하면 좋습니다.

### 변경된 대기열
대기열 개선 방향은 많은 고민을 했지만 발제에 공유해주신 대기열 방식이 가장 합리적이라 판단되어 베이스로 사용헀습니다.

대기열 토큰(Token Queue)을 2개로 관리한다.
1. Waiting Tokens은 2가지 자료구조로 관리합니다.
  - `Sorted Set` 사용: 대기 순번 계산과 대기열의 전반적인 순서를 보장을 위해 `Sorted Set` 자료구조를 사용합니다.
  - `Hash` 사용: `Sorted Set` 자료구조는 추가정보를 저장, 접근하기 어렵기 때문에 정보 저장 목적으로 Hash 자료구조를 사용합니다.
2. Active Tokens
  - Sets를 사용하며, 첫요청이 발생하면 TTL을 부여합니다.


## 3️⃣ 리뷰 포인트
> [!NOTE] 명확한 리뷰 포인트나, 리뷰 받고 싶은 코드를 참조하면 좋습니다.

- 테스트 코드는 아직 수정하지 않았지만 전반적인 흐름을 봐주시면 감사하겠습니다.

## 4️⃣ 이슈
> [!NOTE] (optional) 공유하고 싶은 이슈나, 코드가 가진 문제(한계)를 알려주세요.

- 개발하다 느낀 문제로 Waiting와 Active의 로직과 도메인 객체를 모두 분리하는게 좋겟다는 판단을 했습니다. 테스트 먼저 다듬고 개선을 해볼 예정입니다.

 