### PR TITLE
Fix/대기열 redis 관련 버그 수정

### DIFF
--- a/src/domain/queue/domain/model/queue.domain.ts
+++ b/src/domain/queue/domain/model/queue.domain.ts
@@ -14,13 +14,13 @@ type QueueDomainProp = {
 };
 
 export class QueueDomain {
-  constructor(private readonly prop: QueueDomainProp) {}
+  constructor(readonly prop: QueueDomainProp) {}
 
   /** 활성화 최대 시간(분) - 5분 */
   static MAX_ACTIVE_MINUTE: number = 5 * 60;
 
   get uid(): string {
-    return this.prop.status;
+    return this.prop.uid;
   }
 
   get userId(): number {

--- a/src/domain/queue/domain/queue.service.ts
+++ b/src/domain/queue/domain/queue.service.ts
@@ -9,8 +9,6 @@ import {
 } from './dto';
 import { QueueDomain, QueueEntity, QueueStatus } from './model';
 
-// set hash & zadd
-
 @Injectable()
 export class QueueService {
   constructor(private readonly redisClient: QueueRedisClient) {}
@@ -29,14 +27,13 @@ export class QueueService {
     return CreateQueueInfo.of(QueueDomain.from(param));
   }
 
-  // getWaitQueue
+  // TODO: 네이밍 변경 => getWaitQueue
   async getQueue(queueUid: string): Promise<GetQueueInfo> {
-    const queue = await this.redisClient.getWaitQueue(queueUid);
+    const queue = await this.redisClient.getWaitQueueInfo(queueUid);
     const waitingNumber = await this.redisClient.getWaitingNumber(queue);
     return GetQueueInfo.of({ queue, waitingNumber });
   }
 
-  // 후순위
   async findActiveQueue(queueUid: string): Promise<FindActiveQueueInfo | null> {
     const queue = await this.redisClient.findActiveQueue(queueUid);
     if (queue.isFirstAccessAfterActive) {

--- a/src/domain/queue/infra/queue-redis.client.ts
+++ b/src/domain/queue/infra/queue-redis.client.ts
@@ -19,12 +19,14 @@ export abstract class QueueRedisClient {
   /**
    * 대기열의 토큰 조회
    * @param queueUid
+   * @exception `ResourceNotFoundException`
    */
-  abstract getWaitQueue(queueUid: string): Promise<QueueDomain>;
+  abstract getWaitQueueInfo(queueUid: string): Promise<QueueDomain>;
 
   /**
    * 대기열에서 내 앞의 대기 인원 계산
-   * @returns 앞 대기 인원 수 (본인 제외), 대기열에 없으면 -1 반환
+   * @returns
+   * @exception `ResourceNotFoundException`
    */
   abstract getWaitingNumber(queue: QueueDomain): Promise<number>;
 

--- a/src/global/redis/redis.client.ts
+++ b/src/global/redis/redis.client.ts
@@ -10,6 +10,14 @@ export class RedisClient implements OnModuleDestroy {
   }
 
   /**
+   * 트랜잭션을 시작합니다.
+   * @returns Redis Pipeline
+   */
+  multi(): ChainableCommander {
+    return this.redis.multi();
+  }
+
+  /**
    * 키-값을 조회합니다.
    * @param key 키
    * @returns 저장된 값
@@ -31,31 +39,12 @@ export class RedisClient implements OnModuleDestroy {
   }
 
   /**
-   * 키가 존재하는지 확인합니다.
-   * @param key 키
-   * @returns 존재 여부
-   */
-  async exists(key: string): Promise<boolean> {
-    return (await this.redis.exists(key)) === 1;
-  }
-
-  /**
    * 키를 삭제합니다.
    * @param key 키
    * @returns 삭제된 키의 수
    */
   async del(key: string): Promise<number> {
     return await this.redis.del(key);
-  }
-
-  /**
-   * 키의 만료 시간을 설정합니다.
-   * @param key 키
-   * @param seconds 만료 시간(초)
-   * @returns 성공 여부
-   */
-  async expire(key: string, seconds: number): Promise<boolean> {
-    return (await this.redis.expire(key, seconds)) === 1;
   }
 
   /**
@@ -123,6 +112,8 @@ export class RedisClient implements OnModuleDestroy {
 
   /**
    * zrank 순위를 조회 합니다.
+   * - 자신을 포함한 순위를 계산 합니다. ( +1 보정 )
+   * ex) 앞에 9개가 있다면 10을 리턴합니다.
    * @param key
    * @returns
    */
@@ -134,35 +125,18 @@ export class RedisClient implements OnModuleDestroy {
   /**
    * zscore 점수를 조회 합니다.
    * @param key
+   * @param member - 정학하게 일치하는 해야합니다.
    * @returns
    */
   async zscore(key: string, member: string): Promise<string> {
     return await this.redis.zscore(key, member);
   }
 
-  /**
-   * Set에 여러 값을 추가합니다.
-   * @param key Set 키
-   * @param members 추가할 값들
-   * @returns 추가된 항목 수
-   */
-  async sadd(key: string, ...members: string[]): Promise<number> {
-    return await this.redis.sadd(key, ...members);
-  }
-
-  /**
-   * Set의 모든 멤버를 조회합니다.
-   * @param key Set 키
-   * @returns Set의 모든 멤버
-   */
-  async smembers(key: string): Promise<string[]> {
-    return await this.redis.smembers(key);
-  }
-
   /* ---------------------- Hash ---------------------- */
 
   /**
    * Hash에 단일 필드를 설정합니다.
+   * - redis는 모든 값을 string로 관리한다. 때문에 값이 들어갔다 나오는 경우 모두 문자열이 리턴된다.
    * @param key Hash 키
    * @param field 필드 이름
    * @param value 값
@@ -178,6 +152,7 @@ export class RedisClient implements OnModuleDestroy {
 
   /**
    * Hash에 여러 필드를 한번에 설정합니다.
+   * - redis는 모든 값을 string로 관리한다. 때문에 값이 들어갔다 나오는 경우 모두 문자열이 리턴된다.
    * @param key Hash 키
    * @param data 필드-값 쌍의 객체
    * @returns 성공 여부
@@ -210,16 +185,6 @@ export class RedisClient implements OnModuleDestroy {
   }
 
   /**
-   * Hash에서 특정 필드가 존재하는지 확인합니다.
-   * @param key Hash 키
-   * @param field 필드 이름
-   * @returns 존재 여부
-   */
-  async hexists(key: string, field: string): Promise<boolean> {
-    return (await this.redis.hexists(key, field)) === 1;
-  }
-
-  /**
    * Hash에서 특정 필드를 삭제합니다.
    * @param key Hash 키
    * @param field 필드 이름
@@ -227,13 +192,5 @@ export class RedisClient implements OnModuleDestroy {
    */
   async hdel(key: string, field: string): Promise<number> {
     return await this.redis.hdel(key, field);
-  }
-
-  /**
-   * 트랜잭션을 시작합니다.
-   * @returns Redis Pipeline
-   */
-  multi(): ChainableCommander {
-    return this.redis.multi();
   }
 }


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [ ] 기능 추가(테스트 추가)
- [ ] 기능 개선(테스트 개선)
- [ ] 기능 삭제(테스트 삭제)
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> [!NOTE] 구체적인 작업 내용을 정리하면 좋습니다.

1. 대기열 key 미적용 버그 수정
2. redis 문자열로 형변환 되어 저장되는 특성으로 인한 버그 수정

## 2️⃣ 버그 내용
> [!NOTE] 구현된 코드의 근거나 배경에 대해 설명하면 좋습니다.

### redis 문자열로 형변환 되어 저장되는 특성으로 인한 버그 수정
#### 🔴 버그 상황
요약: "대기열 상태 조회 API"에서 `zset`에 저장된 rank 정보를 불러오지 못하고 404만 응답하는 상황

#### 🟢 정상 프로세스
1. 요청의 `queueUid`를 사용해 `hgetall` 명령을 통해 대기열 info 를 조회한다.  -> 대기열 정보 조회
2. 조회한 info를 json으로 변환해 zset에 저장된 대기열의 `zrank`를 조회한다.    -> 대기 순서 조회
3. 최종적으로 대기열의 상태와 대기 순서가 응답된다.


#### 🔎 에러 상황 분석
`zrank`명령으로 조회를 하려면 저장된 `member`인 json 값과 정확하게 일치해야 한다.
hash에 저장된 데이터와 zset에 저장된 데이터를 각각 비교해 보니 `timestamp`의 타입이 다른 것을 확인했다.


**1) 대기열 순서를 관리하는 sorted set의 json 확인**
![image](https://github.com/user-attachments/assets/2bd550c9-978d-4991-91d6-2efa6c2e4753)
- zrank의 json 데이터에는 `timestamp`가 숫자형으로 저장되어 있다.

**2) hash로 관리되는 대기열 정보 디버그 모드에서 확인**
<img width="908" alt="스크린샷 2024-11-11 오전 1 08 50" src="https://github.com/user-attachments/assets/38d562cf-fb2f-4963-b6f1-74ab3ff4aa6e">
- hash에는 `timestamp`이 문자열로 저장되어 있다.


**3) 이러한 이유로 zrank가 조회가 되지 못하고 계속 -1이 리턴되는 상황이 발생한다.
<img width="617" alt="스크린샷 2024-11-11 오전 1 10 24" src="https://github.com/user-attachments/assets/82d6d2a4-6c2a-4876-ae46-0e79668577f1">

💡)  에러가 왜 발생했는가?
찾아보니 redis는 모든 값을 문자열로 취급해 저장한다고 한다. 때문에 숫자형으로 값을 저장해도 문자열로 변환되어 저장된다. 
그리고 `hgetall`명령으로 값을 조회하면 문자열이 응답된다. 
결과적으로 `hgetall` 명령으로 가져온 데이터와 zset에 저장된 데이터는 다른 값이 된다.

#### ✅ 해결방법
1. 대기열 정보를 관리하는 hash에 `hgetall`로 데이터를 따로 관리하는 것은 안전하지 않기 떄문에 사용하지 않는다.
2. 대기열 정보를 JSON.stringify를 사용해서 sorted set의 json과 동일하게 만든다.
3. `hset` 명령으로 저장한다.   -> `{ "info": json }`

결론
- 이전: `hmset`명령을 사용해 모든 필드를 각각 저장한다.
  ```ts
   override async getWaitQueueInfo(queueUid: string): Promise<QueueDomain> {
    const queueRecord = await this.redisClient.hgetall(
      `${this.WAITING_INFO_KEY}:${queueUid}`,
    );

    if (!queueRecord || Object.keys(queueRecord).length === 0)
      throw new ResourceNotFoundException();
    return QueueDomain.from(queueRecord as any);
  }
  ```
- 수정: `hset` 명령을 사용해 json 데이터를 저장한다.
  ```ts
    override async getWaitQueueInfo(queueUid: string): Promise<QueueDomain> {
    const json = await this.redisClient.hget(
      `${this.WAITING_INFO_KEY}:${queueUid}`,
      'info',
    );
    const queueRecord = JSON.parse(json);

    if (!queueRecord || Object.keys(queueRecord).length === 0)
      throw new ResourceNotFoundException();
    return QueueDomain.from(queueRecord as any);
  }
  ```

## 3️⃣ 리뷰 포인트
> [!NOTE] 명확한 리뷰 포인트나, 리뷰 받고 싶은 코드를 참조하면 좋습니다.

- 

## 4️⃣ 이슈
> [!NOTE] (optional) 공유하고 싶은 이슈나, 코드가 가진 문제(한계)를 알려주세요.

- JSON.stringify -> JSON.parse를 자주 사용하고 싶지 않았지만 결과적으로 한 번의 사용량이 더 늘어났다.
- 그렇기 떄문에 타입을 재대로 잡을 수 있는 효과적인 방법을 찾아보는 것도 좋은 방법이라고 생각된다.

 